### PR TITLE
Add $arch into assets path in print_rsync_iso.sh

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -537,15 +537,20 @@ echo "# Syncing assets"
 declare -A asset_folders''', f)
         for k, v in self.asset_folders.items():
             self.p("asset_folders[{}]='{}'".format(k, v), f)
-        self.p('''while read src; do
+        self.p('''
+for arch in "${archs[@]}"; do
+  while read src; do
     folder=""
     for mask in "${!asset_folders[@]}"; do
         [[ $src =~ $mask ]] || continue
         folder=${asset_folders[$mask]}
         break
     done
+    [[ $folder =~ $arch ]] || [[ PRODUCTPATH =~ $arch ]] || [[ $folder =~ appliances ]] || folder=$arch$folder
     echo "rsync --timeout=3600 -tlp4 --specials PRODUCTPATH/$folder/$src /var/lib/openqa/factory/other/"
-done < <(sort __envsub/files_asset.lst)''', f)
+  done < <(grep $arch __envsub/files_asset.lst | sort)
+done
+''', f)
 
     def gen_print_rsync_iso(self,f):
         print(cfg.header, file=f)

--- a/t/obs/openSUSE:Jump:15.2:Images:ToTest/print_rsync_iso.before
+++ b/t/obs/openSUSE:Jump:15.2:Images:ToTest/print_rsync_iso.before
@@ -14,5 +14,5 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Imag
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Images:ToTest/images/*/livecd-leap-x11/*openSUSE-Jump-15.2.1-Rescue-CD-x86_64-Build2.1-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Jump-15.2.1-Rescue-CD-x86_64-Build2.1-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Images:ToTest/images/*/*vagrant*libvirt*/Leap-15.2.aarch64-15.2-libvirt_aarch64-Build2.1.vagrant.libvirt.box /var/lib/openqa/factory/other/
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Images:ToTest/images/*/*vagrant*libvirt*/Leap-15.2.x86_64-15.2-libvirt-Build2.1.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Images:ToTest/images/aarch64*/*vagrant*libvirt*/Leap-15.2.aarch64-15.2-libvirt_aarch64-Build2.1.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Jump:15.2:Images:ToTest/images/x86_64*/*vagrant*libvirt*/Leap-15.2.x86_64-15.2-libvirt-Build2.1.vagrant.libvirt.box /var/lib/openqa/factory/other/


### PR DESCRIPTION
Fix strange rsync error while copying assets in #97 by explicitly mentioning architecture in path