### PR TITLE
Factory:ARM: Add libvirt.box asset to RPi3 image - poo#73564

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -432,7 +432,7 @@ class ActionBatch:
                     self.p(cfg.read_files_hdd, f, "FOLDER", self.iso_folder.get(hdd,""), "ISOMASK", hdd, '| head -n 1', '', awkpartfrom, awkpartto)
                 else:
                     self.p(cfg.read_files_hdd, f, "FOLDER", self.iso_folder.get(hdd,self.hdd_folder.get(hdd,"")), "ISOMASK", hdd, awkpartfrom, awkpartto)
-        if not self.isos:
+        if not self.isos and not self.hdds:
             for asset in self.assets:
                 self.p(cfg.read_files_hdd, f, "FOLDER", "", "ISOMASK", asset)
         if self.iso_5:
@@ -503,7 +503,7 @@ class ActionBatch:
         # this assumes every flavor has hdd_url - we must store relation if that is not the case
         for fl, h in zip(self.flavors, self.hdds):
             self.p("flavor_filter[{}]='{}'".format(fl, h), f)
-        if not self.isos:
+        if not self.isos and not self.hdds:
             for fl, h in zip(self.flavors, self.assets):
                 self.p("flavor_filter[{}]='{}'".format(fl, h), f)
         for fl, alias_list in self.flavor_aliases.items():
@@ -566,7 +566,7 @@ done < <(sort __envsub/files_asset.lst)''', f)
             self.gen_print_array_flavor_filter(f)
             self.p(cfg.rsync_iso(self.ag.version, self.archs, self.ag.staging(), self.checksum), f)
 
-        if self.assets and self.isos:
+        if self.assets and ( self.isos or self.hdds ):
             self.gen_print_rsync_assets(f)
 
 

--- a/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/files_asset.lst
+++ b/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/files_asset.lst
@@ -1,0 +1,1 @@
+Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box

--- a/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_openqa.before
+++ b/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_openqa.before
@@ -24,7 +24,9 @@
 
 /usr/share/openqa/script/client isos post --host localhost \
  ARCH=aarch64 \
+ ASSET_1=Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box \
  ASSET_256=openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256 \
+ ASSET_LIBVIRT=Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box \
  BUILD=20200115 \
  CHECKSUM_HDD_1=$(cut -b-64 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \

--- a/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_rsync_iso.before
@@ -2,3 +2,6 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:To
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/JeOS:JeOS-efi.aarch64/*openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/JeOS:JeOS-raspberrypi3.aarch64/*openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz /var/lib/openqa/factory/hdd/openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/JeOS:JeOS-raspberrypi3.aarch64/*openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256
+
+# Syncing assets
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/*vagrant*libvirt*/Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box /var/lib/openqa/factory/other/

--- a/xml/obs/openSUSE:Factory:ARM.xml
+++ b/xml/obs/openSUSE:Factory:ARM.xml
@@ -24,6 +24,9 @@
         </flavor>
         <flavor name="JeOS-for-RPi" folder="JeOS:JeOS-raspberrypi3.aarch64">
             <hdd filemask=".*raspberrypi3.*\.raw.xz$"/>
+            <assets archs="aarch64" flavor="DVD">
+                <libvirt folder="appliances/aarch64/*vagrant*libvirt*" filemask="libvirt.box"/>
+            </assets>
         </flavor>
     </batch>
     <batch name="jeos-armv7hl" folder="appliances/armv7l" archs="armv7hl" repos="base">

--- a/xml/obs/openSUSE:Factory:ARM.xml
+++ b/xml/obs/openSUSE:Factory:ARM.xml
@@ -24,8 +24,8 @@
         </flavor>
         <flavor name="JeOS-for-RPi" folder="JeOS:JeOS-raspberrypi3.aarch64">
             <hdd filemask=".*raspberrypi3.*\.raw.xz$"/>
-            <assets archs="aarch64" flavor="DVD">
-                <libvirt folder="appliances/aarch64/*vagrant*libvirt*" filemask="libvirt.box"/>
+            <assets archs="aarch64">
+                <libvirt folder="*vagrant*libvirt*" filemask="libvirt.box"/>
             </assets>
         </flavor>
     </batch>


### PR DESCRIPTION
This should fix the missing asset when testing vagrant on RPi4 - https://progress.opensuse.org/issues/73564