### PR TITLE
Schedule vmware jobs

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -253,7 +253,7 @@ def openqa_call_start_ex1(checksum, tag):
 def openqa_call_start_ex(checksum):
     return ''' if [[ $destiso =~ \.iso$ ]]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'ISO')  + '''\"
- elif [[ $destiso =~ \.(hdd|qcow2|raw\.xz|raw\.gz|vhdx\.xz)$ ]]; then
+ elif [[ $destiso =~ \.(hdd|qcow2|raw\.xz|raw\.gz|vhdx\.xz|vmdk\.xz)$ ]]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'HDD_1')  + '''\"
  elif [ -n "$destiso" ]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'ASSET_1')  + '''\"


### PR DESCRIPTION
[Openqa schedule command](https://openqa.suse.de/admin/obs_rsync/SUSE:SLE-15-SP3:GA:TEST%7Cjeos/runs/.run_last/download/print_openqa.sh) has omitted VMware jobs

After update:
```
declare -A flavor_filter
flavor_filter[JeOS-for-RaspberryPi]='.*JeOS.*RaspberryPi.*\.raw\.xz$'
flavor_filter[JeOS-for-MS-HyperV]='.*JeOS.*MS-HyperV.*\.vhdx\.xz$'
flavor_filter[JeOS-for-kvm-and-xen]='.*JeOS.*kvm-and-xen.*\.qcow2'
flavor_filter[JeOS-for-VMware]='.*JeOS.*VMware.*\.vmdk\.xz$'
declare -A flavor_distri
flavor_distri[JeOS-for-RaspberryPi]='sle'
flavor_distri[JeOS-for-MS-HyperV]='sle'
flavor_distri[JeOS-for-kvm-and-xen]='sle'
flavor_distri[JeOS-for-VMware]='sle'
```