### PR TITLE
[WIP] Rename MicroOS repository extracted from iso

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -52,6 +52,14 @@ def rsync_commands(checksum):
         echo "rsync --timeout=3600 -tlp4 --specials PRODUCTISOPATH/${iso_folder[$flavor]}*$src.sha256 /var/lib/openqa/factory/other/$dest.sha256"'''
     return res
 
+def rsync_iso_rename_suse_microos(version):
+    if '5.0' in version:
+        return '''dest=${dest/DVD/POOL}
+                  dest=${dest/Media/Media1}
+                  dest=${dest/MicroOS-5.0/5.0-MicroOS}'''
+    else:
+        return ''
+
 rsync_iso = lambda version, archs, staging, checksum : '''
 archs=(ARCHITECTURS)
 
@@ -65,6 +73,7 @@ for flavor in {FLAVORLIST,}; do
         dest=$src
         ''' + rsync_iso_staging(version, staging) + '''
         asset_folder=hdd
+        ''' + rsync_iso_rename_suse_microos(version) + ''' 
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
         [[ ! $dest =~ \.appx$  ]] || asset_folder=other
         ''' + rsync_commands(checksum) + '''


### PR DESCRIPTION
SCC proxy returns repo URL to openqa in specific format for instance: *http://openqa.suse.de/assets/repo/\#\{full_product_name\}-POOL-\#\{arch\}-Build\#\{buildnumber.upcase\}-Media1\* that needs to respected in case of MicroOS as well

```
cat t/ibs/SUSE:SLE-15-SP2:Update:Products:MicroOS:Staging:B/files_iso.lst
SUSE-MicroOS.x86_64-5.0.0-Default-Build14.10.raw.xz
SUSE-MicroOS-5.0-DVD-x86_64-Build40.3-Media.iso
```

This pulled iso should be extracted as an openQA repo in this format:

```
cat t/ibs/SUSE:SLE-15-SP2:Update:Products:MicroOS:Staging:B/print_rsync_iso.after 
rsync --timeout=3600 -tlp4 --specials dist.suse.de::repos/SUSE:/SLE-15-SP2:/Update:/Products:/MicroOS:/Staging:/B/images/*SUSE-MicroOS.x86_64-5.0.0-Default-Build14.10.raw.xz /var/lib/openqa/factory/hdd/SUSE-MicroOS.x86_64-5.0.0-Default-BuildB.14.10.raw.xz
rsync --timeout=3600 -tlp4 --specials dist.suse.de::repos/SUSE:/SLE-15-SP2:/Update:/Products:/MicroOS:/Staging:/B/images/*SUSE-MicroOS.x86_64-5.0.0-Default-Build14.10.raw.xz.sha256 /var/lib/openqa/factory/other/SUSE-MicroOS.x86_64-5.0.0-Default-BuildB.14.10.raw.xz.sha256
rsync --timeout=3600 -tlp4 --specials dist.suse.de::repos/SUSE:/SLE-15-SP2:/Update:/Products:/MicroOS:/Staging:/B/images/iso/*SUSE-MicroOS-5.0-DVD-x86_64-Build40.3-Media.iso /var/lib/openqa/factory/iso/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1.iso
rsync --timeout=3600 -tlp4 --specials dist.suse.de::repos/SUSE:/SLE-15-SP2:/Update:/Products:/MicroOS:/Staging:/B/images/iso/*SUSE-MicroOS-5.0-DVD-x86_64-Build40.3-Media.iso.sha256 /var/lib/openqa/factory/other/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1.iso.sha256
[ -d /var/lib/openqa/factory/repo/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1 ] || {
    mkdir /var/lib/openqa/factory/repo/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1
    bsdtar xf /var/lib/openqa/factory/iso/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1.iso -C /var/lib/openqa/factory/repo/SUSE-5.0-MicroOS-POOL-x86_64-BuildB.40.3-Media1
}
```

