### PR TITLE
Disable Factory news on ppc

### DIFF
--- a/t/obs/openSUSE:Factory:PowerPC:ToTest/base/print_openqa.before
+++ b/t/obs/openSUSE:Factory:PowerPC:ToTest/base/print_openqa.before
@@ -94,4 +94,3 @@
  VERSION=Tumbleweed \
  _OBSOLETE=1
 
-/var/lib/openqa/osc-plugin-factory/factory-package-news/factory-package-news.py save --dir /var/lib/snapshot-changes/opensuse-ppc64le/Tumbleweed --snapshot 20200115 /var/lib/openqa/factory/iso/openSUSE-Tumbleweed-DVD-ppc64le-Snapshot20200115-Media.iso

--- a/t/obs/openSUSE:Factory:PowerPC:ToTest/microos/print_openqa.before
+++ b/t/obs/openSUSE:Factory:PowerPC:ToTest/microos/print_openqa.before
@@ -20,5 +20,3 @@
  VERSION=Tumbleweed \
  _OBSOLETE=1
 
-/var/lib/openqa/osc-plugin-factory/factory-package-news/factory-package-news.py save --dir /var/lib/snapshot-changes/microos-ppc64le/Tumbleweed --snapshot 20200115 /var/lib/openqa/factory/iso/openSUSE-MicroOS-DVD-ppc64le-Snapshot20200115-Media.iso
-/var/lib/openqa/osc-plugin-factory/factory-package-news/factory-package-news.py save --dir /var/lib/snapshot-changes/kubic-ppc64le/Tumbleweed --snapshot 20200115 /var/lib/openqa/factory/iso/openSUSE-Kubic-DVD-ppc64le-Snapshot20200115-Media.iso

--- a/xml/obs/openSUSE:Factory:PowerPC.xml
+++ b/xml/obs/openSUSE:Factory:PowerPC.xml
@@ -7,9 +7,8 @@
                 <oss folder="images/local/*openSUSE-ftp-ftp" debug="{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*}" source="{coreutils*,yast2-network*}" mirror="1" dest="openSUSE-Tumbleweed-oss-ppc64_ppc64le"/>
             </repos>
         </flavor>
-        <news iso="Tumbleweed-DVD" archs="ppc64le"/>
     </batch>
     <batch name="microos" folder="images/local/*product*" archs="ppc64le" repos="base" distri="microos">
-        <flavor name="MicroOS-DVD|Kubic-DVD" iso="1" news="ppc64le"/>
+        <flavor name="MicroOS-DVD|Kubic-DVD" iso="1"/>
     </batch>
 </openQA>


### PR DESCRIPTION
The actual command never succeeded because of folder permission.
It looks the news are not needed to anyone, so just disable it