### PR TITLE
Rename rsync_iso_staging to rsync_iso_fix_dest

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -35,7 +35,7 @@ read_files_repo_link2 = '''cp __envdir/REPOLINK/files_iso_buildid.lst __envsub/
 read_files_repo_link3 = '''cp __envdir/REPOLINK/files_iso*.lst __envsub/
 '''
 
-def rsync_iso_staging(version, staging):
+def rsync_fix_dest(distri, version, staging):
     if not staging: return ''
     if version != 'Factory' and len(staging) == 1: return '''dest=${dest//$flavor/Staging:__STAGING-Staging-$flavor}'''
     return '''dest=${dest//$flavor/Staging:__STAGING-$flavor}'''
@@ -52,7 +52,7 @@ def rsync_commands(checksum):
         echo "rsync --timeout=3600 -tlp4 --specials PRODUCTISOPATH/${iso_folder[$flavor]}*$src.sha256 /var/lib/openqa/factory/other/$dest.sha256"'''
     return res
 
-rsync_iso = lambda version, archs, staging, checksum : '''
+rsync_iso = lambda distri, version, archs, staging, checksum : '''
 archs=(ARCHITECTURS)
 
 for flavor in {FLAVORLIST,}; do
@@ -63,7 +63,7 @@ for flavor in {FLAVORLIST,}; do
         ''' + rsync_iso_fix_src(archs) + '''
         [ ! -z "$src" ] || continue
         dest=$src
-        ''' + rsync_iso_staging(version, staging) + '''
+        ''' + rsync_fix_dest(distri, version, staging) + '''
         asset_folder=hdd
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
         [[ ! $dest =~ \.appx$  ]] || asset_folder=other

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -573,12 +573,12 @@ done < <(sort __envsub/files_asset.lst)''', f)
             self.gen_print_array_flavor_filter(f)
             self.gen_print_array_iso_folder(f)
             if self.mask:
-                self.p(cfg.rsync_iso(self.ag.version, self.archs, self.ag.staging(), self.checksum), f, '| head -n 1', '| grep {} | head -n 1'.format(self.mask))
+                self.p(cfg.rsync_iso(self.ag.distri, self.ag.version, self.archs, self.ag.staging(), self.checksum), f, '| head -n 1', '| grep {} | head -n 1'.format(self.mask))
             else:
-                self.p(cfg.rsync_iso(self.ag.version, self.archs, self.ag.staging(), self.checksum), f)
+                self.p(cfg.rsync_iso(self.ag.distri, self.ag.version, self.archs, self.ag.staging(), self.checksum), f)
         elif self.assets:
             self.gen_print_array_flavor_filter(f)
-            self.p(cfg.rsync_iso(self.ag.version, self.archs, self.ag.staging(), self.checksum), f)
+            self.p(cfg.rsync_iso(self.ag.distri, self.ag.version, self.archs, self.ag.staging(), self.checksum), f)
 
         if self.assets and ( self.isos or self.hdds ):
             self.gen_print_rsync_assets(f)


### PR DESCRIPTION
Previously function was used only for changing dest iso in staging,
but it may be useful in other cases as well.