### PR TITLE
Improve consistensy test of print_openqa output

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -160,7 +160,7 @@ for arch in "${archs[@]}"; do
         dest=''' + dest
 
 
-def openqa_call_start_staging(version, staging):
+def openqa_call_fix_destiso(distri, version, staging):
     if not staging:
         return ''
     if (version == 'Factory' or len(staging)>1): 
@@ -198,7 +198,7 @@ def openqa_call_start_meta_variables(meta_variables):
 def pre_openqa_call_start(repos):
     return ''
 
-openqa_call_start = lambda version, archs, staging, news, news_archs, flavor_distri, meta_variables, assets_flavor: '''
+openqa_call_start = lambda distri, version, archs, staging, news, news_archs, flavor_distri, meta_variables, assets_flavor: '''
 archs=(ARCHITECTURS)
 [ ! -f __envsub/files_repo.lst ] || ! grep -q -- "-POOL-" __envsub/files_repo.lst || additional_repo_suffix=-POOL
 
@@ -222,7 +222,7 @@ for flavor in {FLAVORALIASLIST,}; do
         destiso=$iso
         version=VERSIONVALUE
         [ -z "__STAGING" ] || build1=__STAGING.$build
-        ''' + openqa_call_start_staging(version, staging) + '''
+        ''' + openqa_call_fix_destiso(distri, version, staging) + '''
         [ "$arch" != . ] || arch=x86_64
         ''' + openqa_call_news(news, news_archs) + '''
         echo "/usr/share/openqa/script/client isos post --host localhost \\\\\"

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -656,6 +656,7 @@ done < <(sort __envsub/files_asset.lst)''', f)
             self.p(cfg.openqa_call_legacy_builds, f)
 
         i=0
+        isos = self.isos.copy()
         if len(self.hdds) > 1 and not self.isos and len(self.flavors) == 1:
             if self.archs == 'armv7hl':
                 self.p(cfg.openqa_call_start_hdds, f, 'grep ${arch}', 'grep ${arch//armv7hl/armv7l}')
@@ -673,26 +674,26 @@ done < <(sort __envsub/files_asset.lst)''', f)
                 self.p(cfg.openqa_call_start_iso(self.checksum), f, "ISO", "ISO_5")
             else:
                 self.p(cfg.openqa_call_start_iso(self.checksum), f)
-
-            isos = self.isos.copy()
             if not isos and self.iso_5:
                 isos = [self.iso_5]
-            for iso in isos:
-                if self.iso_extract_as_repo.get(iso,0) or self.iso_5:
-                    destiso = "${destiso%.iso}"
-                    i += 1
-                    s = ""
-                    if not self.fixed_iso:
-                        self.p(cfg.openqa_call_repo0(), f, "REPO0_ISO", destiso, f)
-                        s = cfg.openqa_call_repo0a + cfg.openqa_call_repo0b
-                    else:
-                        s = cfg.openqa_call_repo0b
-                        destiso = self.fixed_iso[:-4]
-                    self.p(s, f, "REPO0_ISO", destiso)
-                    if self.iso_5:
-                        pref = self.iso_5.replace("-","_").rstrip('_DVD')
-                        self.p(cfg.openqa_call_repo5, f, "REPOALIAS", "SLE_{}".format(pref))
-                    break # for now only REPO_0
+
+        for iso in isos:
+            if self.iso_extract_as_repo.get(iso,0) or self.iso_5:
+                destiso = "${destiso%.iso}"
+                i += 1
+                s = ""
+                if not self.fixed_iso:
+                    self.p(cfg.openqa_call_repo0(), f, "REPO0_ISO", destiso, f)
+                    s = cfg.openqa_call_repo0a + cfg.openqa_call_repo0b
+                else:
+                    s = cfg.openqa_call_repo0b
+                    destiso = self.fixed_iso[:-4]
+                self.p(s, f, "REPO0_ISO", destiso)
+                if self.iso_5:
+                    pref = self.iso_5.replace("-","_").rstrip('_DVD')
+                    self.p(cfg.openqa_call_repo5, f, "REPOALIAS", "SLE_{}".format(pref))
+                break # for now only REPO_0
+
         arch_expression = ''
         if self.assets_archs:
             arch_expression = '|| [ "$arch" != ' + self.assets_archs + ' ]'

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -301,6 +301,7 @@ class ActionBatch:
                     if node.attrib.get("extract_as_repo",""):
                         self.iso_extract_as_repo[iso] = 1
                     iso = iso_attrib
+                    self.iso_extract_as_repo[iso_attrib] = 1
                 self.isos.append(iso)
 
         if node.attrib.get("name","") and node.attrib.get("folder",""):

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -647,9 +647,9 @@ done < <(sort __envsub/files_asset.lst)''', f)
         if not self.flavors and not self.flavor_aliases:
             return
         if self.mask:
-            self.p(cfg.openqa_call_start(self.ag.version, self.archs, self.ag.staging(), self.news, self.news_archs, self.flavor_distri, self.meta_variables, self.assets_flavor), f, '| grep $arch | head -n 1', '| grep {} | grep $arch | head -n 1'.format(self.mask))
+            self.p(cfg.openqa_call_start(self.ag.distri, self.ag.version, self.archs, self.ag.staging(), self.news, self.news_archs, self.flavor_distri, self.meta_variables, self.assets_flavor), f, '| grep $arch | head -n 1', '| grep {} | grep $arch | head -n 1'.format(self.mask))
         else:
-            self.p(cfg.openqa_call_start(self.ag.version, self.archs, self.ag.staging(), self.news, self.news_archs, self.flavor_distri, self.meta_variables, self.assets_flavor), f)
+            self.p(cfg.openqa_call_start(self.ag.distri, self.ag.version, self.archs, self.ag.staging(), self.news, self.news_archs, self.flavor_distri, self.meta_variables, self.assets_flavor), f)
         if self.repolink and not self.iso_5:
             self.p(cfg.openqa_call_legacy_builds_link, f)
         if self.legacy_builds or (self.repolink and not self.iso_5):

--- a/t/abs/TestExtractAsRepo1/files_iso.lst
+++ b/t/abs/TestExtractAsRepo1/files_iso.lst
@@ -1,0 +1,2 @@
+my-DVD.x86_64-1.1.1-Build1.111.iso
+my-Test.x86_64-1.1.1-Build1.111.raw.xz

--- a/t/abs/TestExtractAsRepo1/print_openqa.before
+++ b/t/abs/TestExtractAsRepo1/print_openqa.before
@@ -1,0 +1,28 @@
+/usr/share/openqa/script/client isos post --host localhost \
+ ARCH=x86_64 \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_HDD_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=HDD \
+ HDD_1=my-Test.x86_64-1.1.1-Build1.111.raw.xz \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+
+/usr/share/openqa/script/client isos post --host localhost \
+ ARCH=x86_64 \
+ ASSET_256=my-DVD.x86_64-1.1.1-Build1.111.iso.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/my-DVD.x86_64-1.1.1-Build1.111.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=DVD \
+ FULLURL=1 \
+ ISO=my-DVD.x86_64-1.1.1-Build1.111.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/my-DVD.x86_64-1.1.1-Build1.111 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/my-DVD.x86_64-1.1.1-Build1.111 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
+ REPO_0=my-DVD.x86_64-1.1.1-Build1.111 \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/my-DVD.x86_64-1.1.1-Build1.111 \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+

--- a/t/abs/TestExtractAsRepo1/print_rsync_iso.before
+++ b/t/abs/TestExtractAsRepo1/print_rsync_iso.before
@@ -1,0 +1,8 @@
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.xz /var/lib/openqa/factory/hdd/my-Test.x86_64-1.1.1-Build1.111.raw.xz
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test/*my-DVD.x86_64-1.1.1-Build1.111.iso /var/lib/openqa/factory/iso/my-DVD.x86_64-1.1.1-Build1.111.iso
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test/*my-DVD.x86_64-1.1.1-Build1.111.iso.sha256 /var/lib/openqa/factory/other/my-DVD.x86_64-1.1.1-Build1.111.iso.sha256
+[ -d /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 ] || {
+    mkdir /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
+    bsdtar xf /var/lib/openqa/factory/iso/my-DVD.x86_64-1.1.1-Build1.111.iso -C /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
+}

--- a/t/test_repo_consistent.sh
+++ b/t/test_repo_consistent.sh
@@ -9,36 +9,51 @@ for dir in "$@" ; do
 	[ -e "$dir"/print_openqa.sh ] || continue
 	[ "$(bash $dir/print_openqa.sh | wc -l)" -gt 1 ] || { >&2 echo "SKIP $dir" && continue; }
 
+    # repo_from_iso is a special case when iso is extracted as repo
+    repos_from_iso="$(bash "$dir"/print_rsync_iso.sh | grep bsdtar | grep -oE '[^ /]+$')" || :
+
 	lines=$(bash "$dir"/print_rsync_repo.sh | grep -v '^#' | grep -v 'set -e' | grep -v '^[[:space:]]*$' | wc -l)
-       	[ "$lines" != "0" ] || { >&2 echo "SKIP $dir"; continue; }
+    [ "$lines$repos_from_iso" != "0" ] || { >&2 echo "SKIP $dir"; continue; }
 
 	# Make sure that destination repo in print_rsync_repo.sh output
 	# exactly matches one of REPO values in print_openqa.sh
 
 	# this must capture all destination file filenames
-	known_destination_repos="$(bash $dir/print_rsync_repo.sh | grep -oE '[^/]+(-Media.?(.license)?/?|-(Snapshot|Build)[0-9]+(.[0-9]+)?)(-debuginfo|-source)?$')" || { >&2 echo "Cannot parse destination REPOs - is print_rsync_repo.sh correct?"; : $((++errs)); continue; }
+	known_destination_repos="$(bash $dir/print_rsync_repo.sh | grep -oE '[^/]+(-Media.?(.license)?/?|-(Snapshot|Build)[0-9]+(.[0-9]+)?)(-debuginfo|-source)?$')"  || :
+    [ -n "$known_destination_repos" ] || [ -z  "$repos_from_iso" ] || { >&2 echo 'print_openqa.sh must have {REPO_0='$(echo "$repos_from_iso"| head -n 1)'}'; : $((++errs)); continue; }
+    [ -n "$known_destination_repos" ] || { >&2 echo "Cannot parse destination REPOs - is print_rsync_repo.sh correct?"; : $((++errs)); continue; }
 
 	# remove trailing /
 	known_destination_repos=$(echo "$known_destination_repos" | grep -o '.*[^/]')
 
-	regex='REPO_[0-9]+=([^[:space:]]*)'
+	regex='REPO_[0-9]+=([^[:space:]]+)'
 	checked=0
+
+    isos_post_repos="$(bash $dir/print_openqa.sh | grep REPO_ )"
 
 	while read -r line; do
 	    if [[ "$line" =~ $regex ]]; then
-            # with REPO_0 it is not a problem when print_rsync_iso has bsdtar (which is indication that REPO_0 comes from print_rsync_iso)
-            if ! echo "$known_destination_repos" | grep -q "${BASH_REMATCH[1]}\$"; then
-                problem_repo=${BASH_REMATCH[1]}
+            problem_repo="${BASH_REMATCH[1]}"
+            line="${line%% *}"
+            line="${line##*=}"
+            if ! echo "$known_destination_repos" | grep -q "$problem_repo"; then
                 [[ "$problem_repo" =~ GM-DVD1 ]] || \
-                ( [[ "$line" =~ REPO_0= ]] && grep -q bsdtar "$dir"/print_rsync_iso.sh ) || \
+                echo "$repos_from_iso" | grep -q "$line" || \
                 ( [[ $dir =~ Update.*RT ]] && [[ ! "$problem_repo" =~ RT  ]] ) || \
                 { >&2 echo "Destination REPO file wasnt found in print_rsync_repo output {$problem_repo}   {$known_destination_repos}"; : $((++errs)); continue 2; }
             fi
             checked=1
 	    fi
-	done < <(bash $dir/print_openqa.sh | grep REPO_ | grep -v 'REPO_5=' | grep -v PACKAGES )
+	done < <(echo "$isos_post_repos" | grep -v 'REPO_5=' | grep -v PACKAGES )
 
 	[ "$checked" == 1 ] || { >&2 echo "No REPO found in openqa request - is something wrong?";  : $((++errs)); continue; }
+
+    for created_repo in $repos_from_iso $known_destination_repos; do
+        [[ ! $created_repo =~ CURRENT ]] || continue
+        created_repo=${created_repo##*=}
+        echo "$isos_post_repos" | grep -q -E "\b$created_repo\b" || { >&2 echo "Synced REPO {$created_repo} wasnt found in print_openqa output {$isos_post_repos}"; : $((++errs)); continue 2; }
+    done
+
 	>&2 echo "PASS $dir"
 done
 

--- a/xml/abs/TestExtractAsRepo.xml
+++ b/xml/abs/TestExtractAsRepo.xml
@@ -1,0 +1,8 @@
+<!-- the purpose of this test is to make sure that DVD gets extracted with bsdtar tool in print_iso output -->
+<!-- it is important that extracted folder is referenced as REPO_0 in print_openqa, otherwise the folder will be automatically removed (ass OpenQA topic regarding "unregistered assets")-->
+<openQA project_pattern="TestExtractAsRepo(?P&lt;version&gt;[1-9])" dist_path="test" archs="x86_64">
+    <flavor name="HDD" distri="distri">
+        <hdd filemask="raw.xz$"/>
+    </flavor>
+    <flavor name="DVD" distri="distri" iso="iso" extract_as_repo="1"/>
+</openQA>


### PR DESCRIPTION
* make sure that isos, extracted in print_rsync_iso are referenced as REPO in isos post;
* make sure that all synced repos are referenced in isos post.