### PR TITLE
Fix rsync complaining file not found for multiplatform assets

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -566,7 +566,7 @@ declare -A asset_folders''', f)
         folder=${asset_folders[$mask]}
         break
     done
-    echo "rsync --timeout=3600 -tlp4 --specials PRODUCTPATH/$folder/$src /var/lib/openqa/factory/other/"
+    echo "rsync --timeout=3600 -tlp4 --specials PRODUCTPATH/$folder/*$src /var/lib/openqa/factory/other/"
 done < <(sort __envsub/files_asset.lst)''', f)
 
     def gen_print_rsync_iso(self,f):

--- a/t/obs/openSUSE:Factory:ARM:ToTest/base/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ARM:ToTest/base/print_rsync_iso.before
@@ -4,4 +4,4 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:To
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/images/local/*product*/*openSUSE-Tumbleweed-DVD-aarch64-Snapshot20200115-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-DVD-aarch64-Snapshot20200115-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/*vagrant*libvirt*/Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200226.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/*vagrant*libvirt*/*Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200226.vagrant.libvirt.box /var/lib/openqa/factory/other/

--- a/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ARM:ToTest/jeos-aarch64/print_rsync_iso.before
@@ -4,4 +4,4 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:To
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/JeOS:JeOS-raspberrypi3.aarch64/*openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-ARM-JeOS-raspberrypi3.aarch64-2020.01.08-Snapshot20200115.raw.xz.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/*vagrant*libvirt*/Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ARM:ToTest/appliances/aarch64/*vagrant*libvirt*/*Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20200115.vagrant.libvirt.box /var/lib/openqa/factory/other/

--- a/t/obs/openSUSE:Factory:ToTest/base/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ToTest/base/print_rsync_iso.before
@@ -8,5 +8,5 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/images/local/*product*/*openSUSE-Tumbleweed-DVD-x86_64-Snapshot20200114-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Tumbleweed-DVD-x86_64-Snapshot20200114-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/*vagrant*libvirt*/Tumbleweed.x86_64-1.0-libvirt-Build20200114.vagrant.libvirt.box /var/lib/openqa/factory/other/
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/*vagrant*virtualbox*/Tumbleweed.x86_64-1.0-virtualbox-Build20200114.vagrant.virtualbox.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/*vagrant*libvirt*/*Tumbleweed.x86_64-1.0-libvirt-Build20200114.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/*vagrant*virtualbox*/*Tumbleweed.x86_64-1.0-virtualbox-Build20200114.vagrant.virtualbox.box /var/lib/openqa/factory/other/

--- a/t/obs/openSUSE:Leap:15.2:ARM:Images:ToTest/print_rsync_iso.before
+++ b/t/obs/openSUSE:Leap:15.2:ARM:Images:ToTest/print_rsync_iso.before
@@ -10,4 +10,4 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:ARM:
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:ARM:Images:ToTest/images/aarch64/livecd-leap-x11/*openSUSE-Leap-15.2-Rescue-CD-aarch64-Snapshot1.42-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Leap-15.2-Rescue-CD-aarch64-Snapshot1.42-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:ARM:Images:ToTest/images/aarch64/*vagrant*libvirt*/Leap-15.2.aarch64-15.2-libvirt_aarch64-Build1.20.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:ARM:Images:ToTest/images/aarch64/*vagrant*libvirt*/*Leap-15.2.aarch64-15.2-libvirt_aarch64-Build1.20.vagrant.libvirt.box /var/lib/openqa/factory/other/

--- a/t/obs/openSUSE:Leap:15.2:Images:ToTest/print_rsync_iso.before
+++ b/t/obs/openSUSE:Leap:15.2:Images:ToTest/print_rsync_iso.before
@@ -8,5 +8,5 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Imag
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Images:ToTest/images/x86_64/livecd-leap-x11/*openSUSE-Leap-15.2-Rescue-CD-x86_64-Snapshot20.3-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Leap-15.2-Rescue-CD-x86_64-Snapshot20.3-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Images:ToTest/images/x86_64/*vagrant*libvirt*/Leap-15.2.x86_64-15.2-libvirt-Build27.4.vagrant.libvirt.box /var/lib/openqa/factory/other/
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Images:ToTest/images/x86_64/*vagrant*virtualbox*/Leap-15.2.x86_64-15.2-virtualbox-Build27.4.vagrant.virtualbox.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Images:ToTest/images/x86_64/*vagrant*libvirt*/*Leap-15.2.x86_64-15.2-libvirt-Build27.4.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.2:Images:ToTest/images/x86_64/*vagrant*virtualbox*/*Leap-15.2.x86_64-15.2-virtualbox-Build27.4.vagrant.virtualbox.box /var/lib/openqa/factory/other/

--- a/t/obs/openSUSE:Leap:15.3:Images:ToTest/print_rsync_iso.before
+++ b/t/obs/openSUSE:Leap:15.3:Images:ToTest/print_rsync_iso.before
@@ -14,5 +14,5 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Imag
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/livecd-leap-x11/*openSUSE-Leap-15.3-Rescue-CD-x86_64-Build3.38-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Leap-15.3-Rescue-CD-x86_64-Build3.38-Media.iso.sha256
 
 # Syncing assets
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/*vagrant*libvirt*/Leap-15.3.aarch64-15.3-libvirt_aarch64-Build3.38.vagrant.libvirt.box /var/lib/openqa/factory/other/
-rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/*vagrant*libvirt*/Leap-15.3.x86_64-15.3-libvirt-Build3.38.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/*vagrant*libvirt*/*Leap-15.3.aarch64-15.3-libvirt_aarch64-Build3.38.vagrant.libvirt.box /var/lib/openqa/factory/other/
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/*vagrant*libvirt*/*Leap-15.3.x86_64-15.3-libvirt-Build3.38.vagrant.libvirt.box /var/lib/openqa/factory/other/


### PR DESCRIPTION
On mutiplatform run rsync might try to search aarch64 files in x86_64 folder and report error "No such file".

```
+ rsync --timeout=3600 -tlp4 --specials 'obspublish::openqa/openSUSE:Leap:15.3:Images:ToTest/images/*/*vagrant*libvirt*/Leap-15.3.aarch64-15.3-libvirt_aarch64-Build3.38.vagrant.libvirt.box' /var/lib/openqa/factory/other/
rsync: link_stat "/openSUSE:Leap:15.3:Images:ToTest/images/x86_64/kiwi-images-vagrant:libvirt/Leap-15.3.aarch64-15.3-libvirt_aarch64-Build3.38.vagrant.libvirt.box" (in openqa) failed: No such file or directory (2)
```

Additional asterisk before file name solves the problem.