### PR TITLE
Support multiarch assets in read_file.sh

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -11,7 +11,7 @@ done
 
 read_files_curl = '''curl -s PRODUCTPATH/ | grep -o 'ISOMASK' | head -n 1 >> __envsub/files_iso.lst'''
 
-read_files_hdd = '''rsync -4 --list-only $rsync_pwd_option PRODUCTPATH/FOLDER/ | grep -o 'ISOMASK' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' | head -n 1 >> __envsub/files_iso.lst
+read_files_hdd = '''rsync -4 --list-only $rsync_pwd_option PRODUCTPATH/FOLDER/ | grep -o 'ISOMASK' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' | grep -E 'ARCHORS' >> __envsub/files_iso.lst
 '''
 
 read_files_iso = '''rsync -4 --list-only $rsync_pwd_option PRODUCTISOPATH/FOLDER/*SRCISO* | grep -P 'Media1?.iso$' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' >> __envsub/files_iso.lst

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -238,7 +238,7 @@ class ActionBatch:
             s=s.replace("ARCHITECTURREPO", self.archs_repo)
         else:
             s=s.replace("ARCHITECTURREPO", self.archs)
-        s=s.replace("ARCHORS", self.archs.replace(" ","|"))
+        s=s.replace("ARCHORS", self.archs.replace(" ","|").replace('armv7hl','armv7hl|armv7l'))
         s=s.replace("SUBFOLDER", self.subfolder)
 
         if self.flavors or self.flavor_aliases_flavor:
@@ -479,7 +479,7 @@ class ActionBatch:
                 self.gen_repo(repodir, gen, f)
             else:
                 archs = repodir.attrib.get("archs", "ARCHORS")
-                self.p(cfg.read_files_repo, f, "PRODUCTREPOPATH", self.ag.productpath + "/" + self.folder + "/*" + repodir.attrib["folder"] + "*", "REPOORS", "", "files_repo.lst", "files_repo_{}.lst".format(os.path.basename(repodir.attrib["folder"]).lstrip('*')), "ARCHORS", archs.replace(' ','|'))
+                self.p(cfg.read_files_repo, f, "PRODUCTREPOPATH", self.ag.productpath + "/" + self.folder + "/*" + repodir.attrib["folder"] + "*", "REPOORS", "", "files_repo.lst", "files_repo_{}.lst".format(os.path.basename(repodir.attrib["folder"]).lstrip('*')), "ARCHORS", archs.replace(' ','|').replace('armv7hl','armv7hl|armv7l'))
 
         # let's sync media.1/media to be able verify build_id
         if 'ToTest' in self.ag.envdir:


### PR DESCRIPTION
Currently xml with assets doesn't work for multiple architectures because it reads only first asset from remote into files_iso.lst
This PR allow reading all assets and also must include tweak for armv7hl which must receive armv7l files:
https://github.com/os-autoinst/openqa-trigger-from-obs/blob/e139442e156869d434e459d9d9f88fdfb0dd7aca/t/obs/openSUSE:Factory:ARM:ToTest/jeos-armv7hl/files_iso.lst#L2