### PR TITLE
Make s390x repo name shorter for Leap

### DIFF
--- a/xml/obs/openSUSE:Leap:15.xml
+++ b/xml/obs/openSUSE:Leap:15.xml
@@ -1,11 +1,12 @@
 <openQA
     project_pattern="openSUSE:Leap:(?P&lt;version&gt;15.[3-9]):ToTest"
     dist_path="images/local"
-    archs="x86_64 aarch64 ppc64le s390x">
-    <flavor name="NET|DVD" folder="*product*" distri="opensuse" iso="1">
+    distri="opensuse"
+    archs="x86_64 aarch64 ppc64le">
+    <flavor name="NET|DVD" folder="*product*" iso="1">
         <repos archs="x86_64">
-            <oss folder="Leap-ftp-ftp" debug="{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*}" source="{coreutils*,yast2-network*}" mirror="1" dest="openSUSE-Leap-${version}-oss-i586-x86_64-aarch64-ppc64le-s390x"/>
-            <non-oss folder="Leap-Addon-NonOss-ftp-ftp"  dest="openSUSE-Leap-${version}-non-oss-i586-x86_64-aarch64-ppc64le-s390x"/>
+            <oss folder="Leap-ftp-ftp" debug="{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*}" source="{coreutils*,yast2-network*}" mirror="1" dest="openSUSE-Leap-${version}-oss-i586-x86_64-aarch64-ppc64le"/>
+            <non-oss folder="Leap-Addon-NonOss-ftp-ftp"  dest="openSUSE-Leap-${version}-non-oss-i586-x86_64-aarch64-ppc64le"/>
         </repos>
     </flavor>
     <news iso="DVD" archs="x86_64"/>

--- a/xml/obs/openSUSE:Leap:15:zSystems.xml
+++ b/xml/obs/openSUSE:Leap:15:zSystems.xml
@@ -1,0 +1,16 @@
+<openQA
+    project_pattern="openSUSE:Leap:(?P&lt;version&gt;15.[3-9]):ToTest"
+    dist_path="images/local"
+    distri="opensuse">
+    <flavor name="DVD" folder="*product*" iso="1" archs="s390x">
+        <repos>
+            <oss folder="Leap-ftp-ftp"
+                debug="{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*}"
+                source="{coreutils*,yast2-network*}"
+                mirror="1"
+                dest="Leap-${version}-oss-$arch"/>
+            <non-oss folder="Leap-Addon-NonOss-ftp-ftp"
+                dest="Leap-${version}-non-oss-$arch"/>
+        </repos>
+    </flavor>
+</openQA>


### PR DESCRIPTION
z/VM parmfile has a length line limit of 72 characters.

- Remove "openSUSE-" prefix to make the name 10 characters shorter
- Dedicate directory to get rid of aarc64-ppc64le-x86_64 in the
directory name