### PR TITLE
Fix the way to get BUILD number for WSL images

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -212,7 +212,7 @@ for flavor in {FLAVORALIASLIST,}; do
         [ $filter != Appliance ] || filter="qcow2"
         iso=$(grep "$filter" __envsub/files_iso.lst | grep $arch | head -n 1)
         ''' + openqa_call_start_fix_iso(archs) + '''
-        build=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*') || :
+        build=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | tail -n 1) || :
         buildex=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*') || :
         [ -n "$iso" ] || [ "$flavor" != "''' + assets_flavor + '''" ] || build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)
         [ -n "$iso" ] || [ "$flavor" != "''' + assets_flavor + '''" ] || buildex=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | head -n 1)


### PR DESCRIPTION
The way it is parsing the build number now generates 2 numbers if
the string contains `SnapshotX` and `BuildY`.
It even returns 2 numbers and messes up the openqa call.

e.g.
`SUSE-Linux-Enterprise-Server-15-SP3--Snapshot12--x64-Build2.209.appx`
returns
```
12
2.209
```
and it keeps `BUILD=12` and `2.209` at the end of the call without variable
assignation, which makes the call to fail.

With this fix, we make sure we keep only 1 of the numbers, specially
the one at the end.