### PR TITLE
CI: Use Mergify for automated PR merging with safety requirements

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - and: &base_checks
+          - base=master
+          - -label~=^acceptance-tests-needed|not-ready
+          - status-success=integration
+          - status-success=unit
+      - and:
+          - "#approved-reviews-by>=1"
+          - "#changes-requested-reviews-by=0"
+          # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
+          - "#review-requested=0"
+    actions:
+      merge:
+        method: merge
+  - name: automatic merge on special label
+    conditions:
+      - and: *base_checks
+      - and:
+          # mergify config checks needs at least two rules in "and" so we repeat
+          # one from the base checks
+          - base=master
+          - label=merge-fast
+    actions:
+      merge:
+        method: merge
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
           - status-success=integration
           - status-success=unit
       - and:
-          - "#approved-reviews-by>=1"
+          - "#approved-reviews-by>=2"
           - "#changes-requested-reviews-by=0"
           # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
           - "#review-requested=0"


### PR DESCRIPTION
Motivation:
Improve development workflow by automating the merging process once all CI
checks pass. This ensures that PRs are not merged manually with missing or
failed CI checks, which can happen if they are not triggered correctly.
Mergify is more diligent in verifying that all required checks are present and
successful.

Design Choices:
- Require at least 2 approvals for safety, mitigating concerns about bad
  actors or account takeovers.
- Only merge if "integration" and "unit" tests pass on the "master" branch.
- Avoid merging if "not-ready" or "acceptance-tests-needed" labels are present.
- Automated conflict notification to prompt authors for fixes.

User Benefits:
- Faster merging of approved and tested contributions.
- Improved reliability by strictly enforcing CI check requirements.
- Consistent automation across the os-autoinst/openQA organization.