### PR TITLE
Add Containers flavor for Leap images

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -213,6 +213,8 @@ for flavor in {FLAVORALIASLIST,}; do
         ''' + openqa_call_start_distri(flavor_distri) + '''
         [[ ! -v flavor_filter[@] ]] || [ -z "${flavor_filter[$flavor]}" ] || filter=${flavor_filter[$flavor]}
         [ $filter != Appliance ] || filter="qcow2"
+        version=VERSIONVALUE
+        if [ -z "${norsync_filter[$flavor]}" ] || [ -z $build1 ]; then {
         iso=$(grep "$filter" __envsub/files_iso.lst 2>/dev/null | grep $arch | head -n 1)
         ''' + openqa_call_start_fix_iso(archs) + '''
         build=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | tail -n 1) || :
@@ -226,13 +228,14 @@ for flavor in {FLAVORALIASLIST,}; do
         buildex=${buildex/.qcow2/}
         build1=$build
         destiso=$iso
-        version=VERSIONVALUE
         [ -z "__STAGING" ] || build1=__STAGING.$build
         ''' + openqa_call_fix_destiso(distri, version, staging) + '''
         repo0folder=${destiso%.iso}
         ''' + (repo0folder if repo0folder else "") + '''
         [ "$arch" != . ] || arch=x86_64
         ''' + openqa_call_news(news, news_archs) + '''
+        }
+        fi
         echo "/usr/bin/openqa-cli api -X post isos \\\\\"
 (
  echo \" DISTRI=$distri \\\\

--- a/t/obs/openSUSE:Leap:15.2:Images:ToTest/print_openqa.before
+++ b/t/obs/openSUSE:Leap:15.2:Images:ToTest/print_openqa.before
@@ -54,3 +54,11 @@
  VERSION=15.2 \
  _OBSOLETE=1
 
+/usr/bin/openqa-cli api -X post isos \
+ ARCH=x86_64 \
+ BUILD=20.3 \
+ DISTRI=opensuse \
+ FLAVOR=Container-Image \
+ VERSION=15.2 \
+ _OBSOLETE=1
+

--- a/t/obs/openSUSE:Leap:15.3:Images:ToTest/print_openqa.before
+++ b/t/obs/openSUSE:Leap:15.3:Images:ToTest/print_openqa.before
@@ -141,3 +141,19 @@
  VERSION=15.3 \
  _OBSOLETE=1
 
+/usr/bin/openqa-cli api -X post isos \
+ ARCH=aarch64 \
+ BUILD=9.269 \
+ DISTRI=opensuse \
+ FLAVOR=Container-Image \
+ VERSION=15.3 \
+ _OBSOLETE=1
+
+/usr/bin/openqa-cli api -X post isos \
+ ARCH=x86_64 \
+ BUILD=9.269 \
+ DISTRI=opensuse \
+ FLAVOR=Container-Image \
+ VERSION=15.3 \
+ _OBSOLETE=1
+

--- a/xml/obs/openSUSE:Leap:15.2:Images.xml
+++ b/xml/obs/openSUSE:Leap:15.2:Images.xml
@@ -1,7 +1,7 @@
 <openQA
     project_pattern="openSUSE:Leap:(?P&lt;version&gt;15.2):Images:ToTest"
     dist_path="images/x86_64"
-    distri="opensuse" 
+    distri="opensuse"
     archs="x86_64">
     <flavor name="JeOS-for-kvm-and-xen" folder="kiwi-templates-JeOS:kvm-and-xen">
         <hdd filemask=".*kvm-and-xen.*\.qcow2"/>
@@ -15,4 +15,7 @@
     <flavor name="GNOME-Live" folder="livecd-leap-gnome" iso="1"/>
     <flavor name="KDE-Live" folder="livecd-leap-kde" iso="1"/>
     <flavor name="Rescue-CD" folder="livecd-leap-x11" iso="1"/>
+    <flavor name="Container-Image">
+        <asset filemask='opensuse-leap-image.*.txt' rsync='0'/>
+    </flavor>
 </openQA>

--- a/xml/obs/openSUSE:Leap:15.2:Images.xml
+++ b/xml/obs/openSUSE:Leap:15.2:Images.xml
@@ -15,7 +15,5 @@
     <flavor name="GNOME-Live" folder="livecd-leap-gnome" iso="1"/>
     <flavor name="KDE-Live" folder="livecd-leap-kde" iso="1"/>
     <flavor name="Rescue-CD" folder="livecd-leap-x11" iso="1"/>
-    <flavor name="Container-Image">
-        <asset filemask='opensuse-leap-image.*.txt' rsync='0'/>
-    </flavor>
+    <flavor name="Container-Image" rsync="0"/>
 </openQA>

--- a/xml/obs/openSUSE:Leap:15.3:Images.xml
+++ b/xml/obs/openSUSE:Leap:15.3:Images.xml
@@ -25,5 +25,5 @@
     <flavor name="KDE-Live" folder="*/livecd-leap-kde" iso="1"/>
     <flavor name="Rescue-CD" folder="*/livecd-leap-x11" iso="1"/>
     <flavor name="XFCE-Live" folder="*/livecd-leap-xfce" iso="1"/>
-    <flavor name="Container-Image"/>
+    <flavor name="Container-Image" rsync="0"/>
 </openQA>

--- a/xml/obs/openSUSE:Leap:15.3:Images.xml
+++ b/xml/obs/openSUSE:Leap:15.3:Images.xml
@@ -25,4 +25,5 @@
     <flavor name="KDE-Live" folder="*/livecd-leap-kde" iso="1"/>
     <flavor name="Rescue-CD" folder="*/livecd-leap-x11" iso="1"/>
     <flavor name="XFCE-Live" folder="*/livecd-leap-xfce" iso="1"/>
+    <flavor name="Container-Image"/>
 </openQA>


### PR DESCRIPTION
This allows creating an additional isos post with specific flavor
to validate container images without reusing JeOS or any other.