### PR TITLE
Fix permission denied for read_files

### DIFF
--- a/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -15,6 +15,11 @@
   /opt/openqa-trigger-from-obs/*:*/*/.run*/* rw,
   /opt/openqa-trigger-from-obs/*:*/*/.run_last rw,
   /opt/openqa-trigger-from-obs/*:*/*/files*.lst rw,
+  /opt/openqa-trigger-from-obs/*:*/*/Media*.lst rw,
+  /opt/openqa-trigger-from-obs/*:*/*/.Media*.lst* rw,
+  /opt/openqa-trigger-from-obs/*:*/*/products* rw,
+  /opt/openqa-trigger-from-obs/*:*/*/.products* rw,
+
   /opt/openqa-trigger-from-obs/*:*/.run*/ rw,
   /opt/openqa-trigger-from-obs/*:*/.run*/* rw,
   /opt/openqa-trigger-from-obs/*:*/.run_last rw,
@@ -97,6 +102,11 @@
     /opt/openqa-trigger-from-obs/*:*/.Media*.lst* rw,
     /opt/openqa-trigger-from-obs/*:*/products* rw,
     /opt/openqa-trigger-from-obs/*:*/.products* rw,
+
+    /opt/openqa-trigger-from-obs/*:*/*/Media*.lst rw,
+    /opt/openqa-trigger-from-obs/*:*/*/.Media*.lst* rw,
+    /opt/openqa-trigger-from-obs/*:*/*/products* rw,
+    /opt/openqa-trigger-from-obs/*:*/*/.products* rw,
 
     /usr/bin/rsync mrix,
     /var/lib/openqa/share/factory/{iso,hdd,repo,other}/** rw,


### PR DESCRIPTION
Following error was observed, this commit attemts to fix it:
`openSUSE:Factory:ToTest/base//read_files.sh: line 5: /opt/openqa-trigger-from-obs/openSUSE:Factory:ToTest/base/Media1_openSUSE-Addon-NonOss-ftp-ftp.lst: Permission denied`

`apparmor="DENIED" name="/opt/openqa-trigger-from-obs/openSUSE:factory:ToTest/base/Media1_openSUSE-Addon-NonOss-ftp-ftp.lst" comm="bash"`