### PR TITLE
Fix regression caused by #170  (fix devel:LEO xml)

### DIFF
--- a/xml/obs/devel:LEO.xml
+++ b/xml/obs/devel:LEO.xml
@@ -8,7 +8,7 @@
 		<flavor name="SelfInstall" folder="ALP:SelfInstall">
 			<hdd filemask="ALP.*-SelfInstall-Build.*install.iso$"/>
 			<repos>
-				<ALP folder="ALP-ftp-POOL"/>
+				<ALP folder="ALP-ftp-POOL" suffix="/"/>
 			</repos>
 		</flavor>
 		<flavor name="SelfInstall_NonTransactional" folder="ALP:SelfInstall_NonTransactional">


### PR DESCRIPTION
Instead of forcing the `/` we provide it in the xml as a suffix.