### PR TITLE
Enable aarch64 images in ALP syncing

### DIFF
--- a/xml/obs/devel:LEO.xml
+++ b/xml/obs/devel:LEO.xml
@@ -3,7 +3,7 @@
 	dist_path="obspublish-other::openqa/devel:LEO/images/*"
     distri="alp"
 	version="0.1"
-    archs="x86_64">
+    archs="x86_64 aarch64">
 	<batch name="base">
 		<flavor name="SelfInstall" folder="ALP:SelfInstall">
 			<hdd filemask="ALP.*-SelfInstall-Build.*install.iso$"/>


### PR DESCRIPTION
Enable aarch64 images in ALP syncing since the images and FTP tree are now built for aarch64 as well.