### PR TITLE
Store uncompressed vmdk in HDD folder

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -71,7 +71,7 @@ for flavor in {FLAVORLIST,}; do
         ''' + rsync_fix_dest(distri, version, staging, use_staging_patterns) + '''
         asset_folder=other
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
-        [[ ! $dest =~ \.(qcow2|raw|vhd|vhdx|xz)$ ]] || asset_folder=hdd
+        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx|xz)$ ]] || asset_folder=hdd
         ''' + rsync_commands(checksum) + '''
         repo0folder=${dest%.iso}
         ''' + (repo0folder if repo0folder else "") + '''


### PR DESCRIPTION
As we had no uncompressed vmdk images before, these images would land in other directory instead of hdd.