### PR TITLE
Missing HDD_1 variable for uncompressed vmdk image

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -284,7 +284,7 @@ def openqa_call_start_ex(checksum):
    :
  elif [[ $destiso =~ \.iso$ ]]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'ISO')  + '''\"
- elif [[ $destiso =~ \.(hdd|qcow2|raw|raw\.xz|raw\.gz|vhdx\.xz|vmdk\.xz)$ ]]; then
+ elif [[ $destiso =~ \.(hdd|qcow2|raw|raw\.xz|raw\.gz|vhdx\.xz|vmdk|vmdk\.xz)$ ]]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'HDD_1')  + '''\"
  elif [ -n "$destiso" ]; then
    echo \" ''' + openqa_call_start_ex1(checksum, 'ASSET_1')  + '''\"


### PR DESCRIPTION
https://openqa.suse.de/tests/14130499#settings