### PR TITLE
Sync json assets to ISO directory instead of other

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -71,6 +71,7 @@ for flavor in {FLAVORLIST,}; do
         ''' + rsync_fix_dest(distri, version, staging, use_staging_patterns) + '''
         asset_folder=other
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
+        [[ ! $dest =~ \.json$  ]] || asset_folder=iso
         [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx|xz)$ ]] || asset_folder=hdd
         ''' + rsync_commands(checksum) + '''
         repo0folder=${dest%.iso}


### PR DESCRIPTION
This is needed by SL Micro maintenance pipeline.
The variable ISO is needed in those tests but the content is not an actually iso, but a json file.