### PR TITLE
Initial trigger for openSUSE:Leap:16.0:Images

### DIFF
--- a/xml/obs/openSUSE:Leap:16.0:Images.xml
+++ b/xml/obs/openSUSE:Leap:16.0:Images.xml
@@ -1,0 +1,7 @@
+<openQA
+    project_pattern="openSUSE:Leap:(?P&lt;version&gt;16.0):Images:ToTest"
+    dist_path="images"
+    distri="opensuse"
+    archs="aarch64 x86_64">
+    <flavor name="agama-installer-openSUSE" folder="*/agama-installer-openSUSE" iso="1"/>
+</openQA>


### PR DESCRIPTION
* we're not yet doing openSUSE:Leap:16.0 as that project contains no installable image. This will have to be solved separately
* Progress Ticket: https://progress.opensuse.org/issues/164141