### PR TITLE
Add openqa_cli property to xml

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -219,7 +219,7 @@ def openqa_call_start_meta_variables(meta_variables):
 def pre_openqa_call_start(repos):
     return ''
 
-openqa_call_start = lambda distri, version, archs, staging, news, news_archs, flavor_distri, meta_variables, assets_flavor, repo0folder: '''
+openqa_call_start = lambda distri, version, archs, staging, news, news_archs, flavor_distri, meta_variables, assets_flavor, repo0folder, openqa_cli: '''
 archs=(ARCHITECTURS)
 [ ! -f __envsub/files_repo.lst ] || ! grep -q -- "-POOL-" __envsub/files_repo.lst || additional_repo_suffix=-POOL
 
@@ -252,7 +252,7 @@ for flavor in {FLAVORALIASLIST,}; do
         ''' + openqa_call_news(news, news_archs) + '''
         }
         fi
-        echo "/usr/bin/openqa-cli api -X post isos?async=1 \\\\\"
+        echo "''' + openqa_cli + ''' \\\\\"
 (
  echo \" DISTRI=$distri \\\\
  ARCH=$arch \\\\

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -16,6 +16,7 @@ class ActionGenerator:
         self.brand = brand
         self.envdir = os.path.join(envdir, project)
         self.distri = ""
+        self.openqa_cli = "/usr/bin/openqa-cli api -X post isos?async=1"
         self.version = version
         self.batches = []
         project = project.split("::")[0]
@@ -63,6 +64,8 @@ class ActionGenerator:
         self.version = root.attrib.get("version", self.version)
         if root.attrib.get("distri", ""):
             self.distri = root.attrib["distri"]
+
+        self.openqa_cli = root.attrib.get("openqa_cli", self.openqa_cli)
 
         for t in root.findall(".//batch"):
             batch = self.doBatch(t)
@@ -955,6 +958,7 @@ done < <(sort __envsub/files_asset.lst)""",
                     self.meta_variables,
                     self.assets_flavor,
                     self.repo0folder,
+                    self.ag.openqa_cli,
                 ),
                 f,
                 "| grep $arch | head -n 1",
@@ -973,6 +977,7 @@ done < <(sort __envsub/files_asset.lst)""",
                     self.meta_variables,
                     self.assets_flavor,
                     self.repo0folder,
+                    self.ag.openqa_cli,
                 ),
                 f,
             )

--- a/t/abs/Test1/print_openqa.before
+++ b/t/abs/Test1/print_openqa.before
@@ -1,4 +1,4 @@
-/usr/bin/openqa-cli api -X post isos?async=1 \
+echo \
  ARCH=x86_64 \
  ASSET_256=my-iso.x86_64-1.1.1-Build1.111.iso.sha256 \
  BUILD=1.111 \

--- a/xml/abs/Test.xml
+++ b/xml/abs/Test.xml
@@ -1,3 +1,3 @@
-<openQA project_pattern="Test(?P&lt;version&gt;[1-9])" dist_path="test1">
+<openQA project_pattern="Test(?P&lt;version&gt;[1-9])" dist_path="test1" openqa_cli="echo">
     <flavor name="FLAVOR" distri="distri" iso="iso"/>
 </openQA>


### PR DESCRIPTION
The idea is that some projects can put custom wrapper instead of openqa-cli calls.
That wrapper can manage generated parameters as needed, make additional calls, etc.