### PR TITLE
Allow entering custom meta variables

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -81,6 +81,8 @@ class ActionGenerator:
             batches_string = root.attrib.get("batches", "default")
             for b in batches_string.split("|"):
                 batch = self.doBatch(root, b)
+                if root.attrib.get("metavars"):
+                    batch.meta_variables = root.attrib.get("metavars")
                 if batch:
                     for news in root.findall(".//news"):
                         if news.attrib.get("iso", ""):


### PR DESCRIPTION
This will help override default meta variables like _OBSOLETE=1

I've tried this feature with an xml with `metavars="_OBSOLETE=0"` and I get it right in the isos post.
Example of usage (internal only): https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/194