### PR TITLE
Remove iso_path="iso" for agama s390x

### DIFF
--- a/t/obs/systemsmanagement:Agama:Devel/s390x/files_iso.lst
+++ b/t/obs/systemsmanagement:Agama:Devel/s390x/files_iso.lst
@@ -2,3 +2,7 @@ agama-installer.aarch64-9.0.0-openSUSE-Build17.9.iso
 agama-installer.ppc64le-9.0.0-openSUSE-Build17.9.iso
 agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso
 agama-installer.x86_64-9.0.0-openSUSE-Build17.9.iso
+agama-installer.aarch64-9.0.0-openSUSE-Build17.19.iso
+agama-installer.ppc64le-9.0.0-openSUSE-Build17.19.iso
+agama-installer.s390x-9.0.0-openSUSE-Build17.19.iso
+agama-installer.x86_64-9.0.0-openSUSE-Build17.19.iso

--- a/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
+++ b/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
@@ -1,5 +1,5 @@
-rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//iso/images/*/agama-installer:openSUSE//*agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso
-rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//iso/images/*/agama-installer:openSUSE//*agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso.sha256 /var/lib/openqa/factory/other/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso
+rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso.sha256 /var/lib/openqa/factory/other/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso.sha256
 [ -d /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso -C /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9

--- a/xml/obs/systemsmanagement:Agama:Devel.xml
+++ b/xml/obs/systemsmanagement:Agama:Devel.xml
@@ -6,7 +6,7 @@
     <batch name="base" archs="86_64 aarch64 ppc64le">
         <flavor name="agama-installer" folder="images/*/agama-installer:openSUSE/" iso="1" media1="0"/>
     </batch>
-    <batch name="s390x" archs="s390x" iso_path="iso">
+    <batch name="s390x" archs="s390x">
 	<flavor name="agama-installer" folder="images/*/agama-installer:openSUSE/" iso="extract_as_repo" media1="0"/>
     </batch>
 </openQA>


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/166253