### PR TITLE
Fix x86_64 arch typo in systemsmanagement:Agama:Devel.xml file

### DIFF
--- a/t/obs/systemsmanagement:Agama:Devel/base/print_openqa.before
+++ b/t/obs/systemsmanagement:Agama:Devel/base/print_openqa.before
@@ -1,5 +1,5 @@
 /usr/bin/openqa-cli api -X post isos?async=1 \
- ARCH=86_64 \
+ ARCH=x86_64 \
  ASSET_256=agama-installer.x86_64-9.0.0-openSUSE-Build17.9.iso.sha256 \
  BUILD=17.9 \
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/agama-installer.x86_64-9.0.0-openSUSE-Build17.9.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \

--- a/xml/obs/systemsmanagement:Agama:Devel.xml
+++ b/xml/obs/systemsmanagement:Agama:Devel.xml
@@ -3,7 +3,7 @@
     dist_path="obspublish-other::openqa/systemsmanagement:Agama:Devel/"
     distri="opensuse"
     version="agama-9.0">
-    <batch name="base" archs="86_64 aarch64 ppc64le">
+    <batch name="base" archs="x86_64 aarch64 ppc64le">
         <flavor name="agama-installer" folder="images/*/agama-installer:openSUSE/" iso="1" media1="0"/>
     </batch>
     <batch name="s390x" archs="s390x">


### PR DESCRIPTION
We have detected a problem in mentioned XML file that lead to some jobs not launched.
This PR solves that.