### PR TITLE
Remove .install suffix for repo files on MicroOS-SelfInstall flavor

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -652,7 +652,7 @@ class ActionBatch:
                     cfg.read_files_repo,
                     f,
                     txt,
-                    self.ag.productpath + "/" + self.folder + "/*" + repodir.attrib["folder"] + "*" + suffix,
+                    self.ag.productpath + "/" + self.folder + "/*" + repodir.attrib["folder"] + "*" + suffix.replace('.install', ''),
                     "REPOORS",
                     "",
                     "files_repo.lst",


### PR DESCRIPTION
* Related ticket: https://progress.opensuse.org/issues/170158
* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20748