### PR TITLE
Add Slowroll DVD

### DIFF
--- a/t/obs/openSUSE:Slowroll:Build:iso/files_iso.lst
+++ b/t/obs/openSUSE:Slowroll:Build:iso/files_iso.lst
@@ -1,0 +1,1 @@
+openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso

--- a/t/obs/openSUSE:Slowroll:Build:iso/print_openqa.before
+++ b/t/obs/openSUSE:Slowroll:Build:iso/print_openqa.before
@@ -1,0 +1,11 @@
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_256=openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso.sha256 \
+ BUILD=30.1 \
+ CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=opensuse \
+ FLAVOR=DVD \
+ ISO=openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso \
+ VERSION=slowroll \
+ _OBSOLETE=1
+

--- a/t/obs/openSUSE:Slowroll:Build:iso/print_rsync_iso.before
+++ b/t/obs/openSUSE:Slowroll:Build:iso/print_rsync_iso.before
@@ -1,0 +1,2 @@
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Slowroll:Build:iso/images/*/000product*/*openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso /var/lib/openqa/factory/iso/openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Slowroll:Build:iso/images/*/000product*/*openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso.sha256 /var/lib/openqa/factory/other/openSUSE-Slowroll-DVD-x86_64-Build30.1-Media.iso.sha256

--- a/xml/obs/openSUSE:Slowroll.xml
+++ b/xml/obs/openSUSE:Slowroll.xml
@@ -1,0 +1,7 @@
+<openQA
+    project_pattern="openSUSE:Slowroll:Build:iso"
+    dist_path="images/*/000product*"
+    distri="opensuse"
+    version="slowroll">
+    <flavor name="DVD" distri="opensuse" iso="1" media1="0"></flavor>
+</openQA>


### PR DESCRIPTION
Adds openSUSE Slowroll (DVD) to the scheduling.

* Related ticket: https://progress.opensuse.org/issues/177859
* Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/610