### PR TITLE
Avoid warning about escape sequence in python 3.12

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -486,7 +486,7 @@ class ActionBatch:
     def gen_repo(self, repodir, gen, f):
         if "$build" in gen:
             self.p(
-                """build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_iso.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)""",
+                r"""build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_iso.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)""",
                 f,
             )
         body = gen


### PR DESCRIPTION
https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes

    /opt/openqa-trigger-from-ibs/script/scriptgen.py:489: SyntaxWarning: invalid escape sequence '\.'
        """build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_iso.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)""",