### PR TITLE
Restrict Leap DVD to Leap 15.5+

### DIFF
--- a/xml/obs/openSUSE:Leap:15.xml
+++ b/xml/obs/openSUSE:Leap:15.xml
@@ -1,5 +1,5 @@
 <openQA
-    project_pattern="openSUSE:Leap:(?P&lt;version&gt;15.[3-9]):ToTest"
+    project_pattern="openSUSE:Leap:(?P&lt;version&gt;15.[5-9]):ToTest"
     dist_path="images/local"
     archs="x86_64 aarch64 ppc64le s390x">
     <flavor name="NET|DVD" folder="*product*" distri="opensuse" iso="1">


### PR DESCRIPTION
There is no point in syncing Leap 15.3 and Leap 15.4 anymore.