### PR TITLE
Add handling for MIRROR_* variables

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -363,6 +363,14 @@ def openqa_call_repo0():
  FULLURL=1 \\\\"
     }'''
 
+def openqa_call_repo_unconditional():
+    return ''' echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
+ FULLURL=1 \\\\"
+    '''
+
 openqa_call_repo0a = ' [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || '
 
 openqa_call_repo0b = ' echo " REPO_0=REPO0_ISO \\\\"'

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1041,6 +1041,8 @@ done < <(sort __envsub/files_asset.lst)""",
                     " echo \" REPO_{}_SOURCE_PACKAGES='{}'\" \\\\".format(repo.tag.upper(), repo.get("source", "")), f
                 )
                 imultiarch = imultiarch + 1
+            if imultiarch > 0:
+                self.p(cfg.openqa_call_repo_unconditional(), f, "REPO0_ISO", '{}-$buildex'.format(dest))
 
         if len(self.iso1) > 0:
             self.p(' iso1=""', f)

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1042,7 +1042,7 @@ done < <(sort __envsub/files_asset.lst)""",
                 )
                 imultiarch = imultiarch + 1
             if imultiarch > 0:
-                self.p(cfg.openqa_call_repo_unconditional(), f, "REPO0_ISO", '{}-$buildex'.format(dest))
+                self.p(cfg.openqa_call_repo_unconditional(), f, "REPO0_ISO", "{}-$buildex".format(dest))
 
         if len(self.iso1) > 0:
             self.p(' iso1=""', f)

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1022,6 +1022,7 @@ done < <(sort __envsub/files_asset.lst)""",
             )
 
         imultiarch = 0
+        mirrorsalreadyadded = False
         for repo in self.reposmultiarch:
             destpath = repo.get("folder", repo.tag)
             destpath = destpath.rstrip("/")
@@ -1041,8 +1042,9 @@ done < <(sort __envsub/files_asset.lst)""",
                     " echo \" REPO_{}_SOURCE_PACKAGES='{}'\" \\\\".format(repo.tag.upper(), repo.get("source", "")), f
                 )
                 imultiarch = imultiarch + 1
-            if imultiarch > 0:
+            if imultiarch > 0 and repo.get("mirror", 0) and not mirrorsalreadyadded:
                 self.p(cfg.openqa_call_repo_unconditional(), f, "REPO0_ISO", "{}-$buildex".format(dest))
+                mirrorsalreadyadded = True
 
         if len(self.iso1) > 0:
             self.p(' iso1=""', f)

--- a/t/obs/openSUSE:Leap:16.0:ToTest/print_openqa.before
+++ b/t/obs/openSUSE:Leap:16.0:ToTest/print_openqa.before
@@ -5,12 +5,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/agama-installer-Leap.aarch64-16.0.0-Leap-Build1.3.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=agama-installer-Leap \
+ FULLURL=1 \
  ISO=agama-installer-Leap.aarch64-16.0.0-Leap-Build1.3.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -21,12 +26,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/agama-installer-Leap.x86_64-16.0.0-Leap-Build1.3.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=agama-installer-Leap \
+ FULLURL=1 \
  ISO=agama-installer-Leap.x86_64-16.0.0-Leap-Build1.3.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -37,12 +47,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/agama-installer-Leap.ppc64le-16.0.0-Leap-Build1.3.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=agama-installer-Leap \
+ FULLURL=1 \
  ISO=agama-installer-Leap.ppc64le-16.0.0-Leap-Build1.3.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -53,12 +68,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/agama-installer-Leap.s390x-16.0.0-Leap-Build1.3.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=agama-installer-Leap \
+ FULLURL=1 \
  ISO=agama-installer-Leap.s390x-16.0.0-Leap-Build1.3.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -69,12 +89,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/Leap-16.0-offline-installer-aarch64-Build1.3.install.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=offline-installer \
+ FULLURL=1 \
  ISO=Leap-16.0-offline-installer-aarch64-Build1.3.install.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -85,12 +110,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/Leap-16.0-offline-installer-x86_64-Build1.3.install.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=offline-installer \
+ FULLURL=1 \
  ISO=Leap-16.0-offline-installer-x86_64-Build1.3.install.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -101,12 +131,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/Leap-16.0-offline-installer-ppc64le-Build1.3.install.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=offline-installer \
+ FULLURL=1 \
  ISO=Leap-16.0-offline-installer-ppc64le-Build1.3.install.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 
@@ -117,12 +152,17 @@
  CHECKSUM_ISO=$(cut -b-64 /var/lib/openqa/factory/other/Leap-16.0-offline-installer-s390x-Build1.3.install.iso.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
  DISTRI=opensuse \
  FLAVOR=offline-installer \
+ FULLURL=1 \
  ISO=Leap-16.0-offline-installer-s390x-Build1.3.install.iso \
+ MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
+ MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \
  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_1=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  REPO_LEAP_OSS_DEBUG=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Debug-Build1.3 \
  REPO_LEAP_OSS_DEBUG_PACKAGES='{java*,kernel-default-debug*,kernel-default-base-debug*,mraa-debug*,wicked-debug*}' \
+ SUSEMIRROR=http://openqa.opensuse.org/assets/repo/Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build1.3 \
  VERSION=16.0 \
  _OBSOLETE=1
 


### PR DESCRIPTION
`MIRROR_PREFIX` is one of the variables needed for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22054

