### PR TITLE
Draft: MiminalVM tests add openSUSE:Leap:16.0:Images

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1206,7 +1206,7 @@ def parse_dir(root, d, files):
             continue
 
         rootXml = ElementTree.parse(root + "/" + f).getroot()
-        if not rootXml:
+        if not len(rootXml):
             print("Ignoring [" + f + "]: Cannot parse xml", file=sys.stderr)
             continue
 

--- a/xml/obs/openSUSE:Leap:16.0:Images.xml
+++ b/xml/obs/openSUSE:Leap:16.0:Images.xml
@@ -3,5 +3,13 @@
     dist_path="images"
     distri="opensuse"
     archs="aarch64 x86_64">
-    <flavor name="agama-installer-openSUSE" folder="*/*agama-installer-openSUSE*" iso="1" media1="0"/>
+    <flavor name="Minimal-VM-for-kvm-and-xen" folder="*/kiwi-templates-Minimal:kvm-and-xen">
+        <hdd filemask=".*kvm-and-xen.*\.qcow2$"/>
+    </flavor>
+    <flavor name="Minimal-VM-for-kvm-and-xen-encrypt" folder="*/kiwi-templates-Minimal:kvm-and-xen-encrypt">
+        <hdd filemask=".*kvm-and-xen-encrypt.*\.qcow2$"/>
+    </flavor>
+    <flavor name="Minimal-VM-Cloud" folder="*/kiwi-templates-Minimal:Cloud">
+        <hdd filemask=".*Minimal-VM.*-Cloud-.*\.qcow2$"/>
+    </flavor>
 </openQA>


### PR DESCRIPTION
MiminalVM tests add openSUSE:Leap:16.0:Images.
openSUSE:Leap:16.0:Images.xml updated

Ticket: https://progress.opensuse.org/issues/176547
VR: see next PR posts.