### PR TITLE
Add openqa/public needed by openqa-cli to apparmor

### DIFF
--- a/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -75,7 +75,7 @@
     /opt/openqa-trigger-from-obs/*:*/*/.run*/openqa*.log w,
     /opt/openqa-trigger-from-obs/*:*/.run*/openqa*.log w,
     /usr/bin/openqa-cli rix,
-    /usr/share/openqa/lib/** r,
+    /usr/share/openqa/** r,
     /usr/share/openqa/script/openqa-cli rix,
     /var/lib/openqa/.config/openqa/client.conf r,
     /var/lib/openqa/share/factory/{iso,hdd,repo,other}/** r,


### PR DESCRIPTION
The file openqa-cli.yaml needs to be readable.

See: https://github.com/os-autoinst/openQA/pull/6316