### PR TITLE
Add abstractions/openssl to rsync apparmor profile

### DIFF
--- a/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -85,6 +85,7 @@
   profile rsync flags=(attach_disconnected) {
     #include <abstractions/base>
     #include <abstractions/nameservice>
+    #include <abstractions/openssl>
 
     capability net_bind_service,
 


### PR DESCRIPTION
To address denials like this:

    type=AVC msg=audit(1753252655.471:303648): apparmor="DENIED" operation="open" class="file" profile="/opt/openqa-trigger-from-obs/script/rsync.sh//rsync" name="/etc/ssl/openssl.cnf" pid=19240 comm="rsync" requested_mask="r" denied_mask="r" fsuid=493 ouid=0