### PR TITLE
Include livepatches variables in openqa.cmd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           command: |
-            zypper -n in --no-recommends diffutils make python3 tar git-core
+            zypper -n in --no-recommends diffutils make python3 tar git-core python3-requests python3-beautifulsoup4
       - checkout
       - run: git clean -df
       - run: make test_regen_all

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1008,6 +1008,12 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 "| grep {} | grep $arch | head -n 1".format(self.mask),
             )
         else:
+            livepatch_updates = cfg.openqa_fetch_livepatch_list(self.ag)
+            openqa_livepatches = {}
+            if livepatch_updates:
+                openqa_livepatches = {
+                    f"{arch}:{' '.join(versions)}" for arch, versions in livepatch_updates.items() if versions
+                }
             self.p(
                 cfg.openqa_call_start(
                     self.ag.distri,
@@ -1021,6 +1027,7 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                     self.assets_flavor,
                     self.repo0folder,
                     self.ag.openqa_cli,
+                    openqa_livepatches,
                 ),
                 f,
             )

--- a/t/podman/lib/test-in-container-systemd.sh
+++ b/t/podman/lib/test-in-container-systemd.sh
@@ -58,7 +58,8 @@ until [ $counter -gt 10 ]; do
 done
 
 podman exec "$containername" pwd >& /dev/null || (echo Cannot start container; exit 1 ) >&2
-
+# install python dependencies
+podman exec "$containername" bash zypper -y in python3-requests python3-beautifulsoup4
 podman exec "$containername" bash /opt/init-trigger-from-obs.sh
 
 [ -z "$CIRCLE_JOB" ] || echo 'aa-complain /usr/share/openqa/script/openqa' | podman exec "$containername" bash -x


### PR DESCRIPTION
Automate the livepatch isos posts. Due to the logic of the script generation this commit contains an injection of a for loop for all the livepatches which will be found in the spdx.json, after the sync in the server.

- the loop always run even if no livepatches found. However it will only append to the isos posts the variable in the case that actually livepatch versions inclue in the array. The approach is just a bit dirty, as any other approach would require further and bigger changes.
- The injection is in the `rsync_iso` after all the necessary variables are set and before the beginning writing to the print_openqa.sh. At that point the `spdx.json` should be available and it needs only to grep for the _kernel_livepatch_ in the server. Before that point, the scriptgen.py would have to make a request to each repo in the dist.s.d and it is likely it would be less flexible as the logic of the _isos post_ is mainly in the generated `print_openqa.sh`.

depends-on: https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/263
issue: https://progress.opensuse.org/issues/190134