### PR TITLE
fix(mergify): generalize CI targets to wait on

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,8 +4,8 @@ pull_request_rules:
       - and: &base_checks
           - base=master
           - -label~=^acceptance-tests-needed|not-ready
-          - status-success=integration
-          - status-success=unit
+          - "#check-pending=0"
+          - "#check-failure=0"
       - and:
           - "#approved-reviews-by>=2"
           - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
When the mergify configuration was originally proposed CI jobs were called
differently. To fix this while relying less on actual names we can just rely
on no jobs pending or failing.