### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,6 +3,9 @@ name: CI
 
 on: [pull_request, workflow_dispatch]  # yamllint disable-line rule:truthy
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/openqa-trigger-from-obs/security/code-scanning/1](https://github.com/os-autoinst/openqa-trigger-from-obs/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best single fix here: add a workflow-level permissions block with `contents: read`, since the shown job only needs repository read access for `actions/checkout` and test execution. This preserves existing functionality while preventing unintended write scope inherited from repo/org defaults.

Change required in `.github/workflows/integration.yaml`:
- Insert after the `on:` section (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
