### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: integration
         run: |
           podman pull registry.opensuse.org/devel/openqa/ci/containers/serviced


### PR DESCRIPTION
This also fixes a warning about outdated nodejs