### PR TITLE
fix(style): resolve ruff E701 and E731 violations, add type checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   unit:
     docker:
-      - image: registry.opensuse.org/opensuse/leap:15.5
+      - image: registry.opensuse.org/opensuse/leap:16.0
     steps:
       - checkout
       - run:
@@ -21,9 +21,10 @@ jobs:
       - checkout
       - run:
           command: |
-            zypper -n in --no-recommends make python3-black python3-importlib-metadata
+            zypper -n in --no-recommends make python3-uv python3-importlib-metadata
       - checkout
-      - run: make test_python_style
+      - run: |
+          make test_python_style
 
 workflows:
   version: 2.1

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,6 @@ test_update_before_files: test_regen_all
 	(cd t && bash test_before_after_diff.sh --update-before *bs/*)
 
 test_python_style:
-	black --check --fast --diff script/scriptgen.py 
+	uv run ruff check
+	uv run ruff format --check
+	uv run ty check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,16 @@
+[project]
+name = "openqa-trigger-from-obs"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15",
+    "ty>=0.0.26",
+]
+
+[tool.ruff]
+exclude = ["script/ibs.py"]
+
 [tool.black]
 line-length = 120

--- a/script/abs.py
+++ b/script/abs.py
@@ -1,7 +1,6 @@
-import scriptgen
 import cfg
 
-cfg.header = '''# GENERATED FILE - DO NOT EDIT
+cfg.header = """# GENERATED FILE - DO NOT EDIT
 set -e
 # abstract test config
-'''
+"""

--- a/script/cfg.py
+++ b/script/cfg.py
@@ -1,64 +1,80 @@
 import os
 
-header = '''# GENERATED FILE - DO NOT EDIT
+header: str = """# GENERATED FILE - DO NOT EDIT
 set -e
-'''
+"""
 
-clear_lst = '''for f in __envsub/{files_,Media}*.lst; do
+clear_lst = """for f in __envsub/{files_,Media}*.lst; do
     [ ! -f "$f" ] ||  : > "$f"
 done
 
 [ ! -f __envdir/../rsync.secret ] || rsync_pwd_option=--password-file=__envdir/../rsync.secret
-'''
+"""
 
-read_files_curl = '''curl -s PRODUCTPATH/ | grep -o 'ISOMASK' | head -n 1 >> __envsub/files_iso.lst'''
+read_files_curl = (
+    """curl -s PRODUCTPATH/ | grep -o 'ISOMASK' | head -n 1 >> __envsub/files_iso.lst"""
+)
 
-read_files_hdd = '''rsync -4 --list-only $rsync_pwd_option PRODUCTPATH/FOLDER/ | grep -o 'ISOMASK' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' | grep -E 'ARCHORS' >> __envsub/files_iso.lst
-'''
+read_files_hdd = """rsync -4 --list-only $rsync_pwd_option PRODUCTPATH/FOLDER/ | grep -o 'ISOMASK' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' | grep -E 'ARCHORS' >> __envsub/files_iso.lst
+"""
 
-read_files_iso = '''rsync -4 --list-only $rsync_pwd_option PRODUCTISOPATH/FOLDER/*SRCISO* | grep -P 'Media1?.iso$' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' >> __envsub/files_iso.lst
-'''
+read_files_iso = """rsync -4 --list-only $rsync_pwd_option PRODUCTISOPATH/FOLDER/*SRCISO* | grep -P 'Media1?.iso$' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' >> __envsub/files_iso.lst
+"""
 
-read_files_isos = '''rsync -4 --list-only $rsync_pwd_option PRODUCTISOPATH/ | grep -P 'Media1?.iso$' | grep -E 'ARCHORS' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' >> __envsub/files_iso.lst
-'''
+read_files_isos = """rsync -4 --list-only $rsync_pwd_option PRODUCTISOPATH/ | grep -P 'Media1?.iso$' | grep -E 'ARCHORS' | awk '{ $1=$2=$3=$4=""; print substr($0,5); }' >> __envsub/files_iso.lst
+"""
 
-read_files_repo = '''rsync -4 --list-only $rsync_pwd_option PRODUCTREPOPATH/ | grep '^d' | grep -P 'Media[1-3](.license)?$' | awk '{ $1=$2=$3=$4=""; print substr($0,5); } ' | grep -v IGNOREPATTERN | grep -E 'REPOORS' | grep -E 'ARCHORS'  >> __envsub/files_repo.lst
-'''
+read_files_repo = """rsync -4 --list-only $rsync_pwd_option PRODUCTREPOPATH/ | grep '^d' | grep -P 'Media[1-3](.license)?$' | awk '{ $1=$2=$3=$4=""; print substr($0,5); } ' | grep -v IGNOREPATTERN | grep -E 'REPOORS' | grep -E 'ARCHORS'  >> __envsub/files_repo.lst
+"""
 
-read_files_repo_media = '''rsync -4 $rsync_pwd_option PRODUCTREPOPATH/*Media1/media.1/media __envsub/Media1.lst'''
-read_files_repo_media_convert = r''' && echo "Snapshot$(grep -oP '[\d]{8}' __envsub/products)" >> __envsub/destlst'''
+read_files_repo_media = """rsync -4 $rsync_pwd_option PRODUCTREPOPATH/*Media1/media.1/media __envsub/Media1.lst"""
+read_files_repo_media_convert = r""" && echo "Snapshot$(grep -oP '[\d]{8}' __envsub/products)" >> __envsub/destlst"""
 
-read_files_repo_link = '''cp __envdir/REPOLINK/files_repo*.lst __envsub/
-'''
+read_files_repo_link = """cp __envdir/REPOLINK/files_repo*.lst __envsub/
+"""
 
-read_files_repo_link2 = '''cp __envdir/REPOLINK/files_iso_buildid.lst __envsub/
-'''
+read_files_repo_link2 = """cp __envdir/REPOLINK/files_iso_buildid.lst __envsub/
+"""
 
-read_files_repo_link3 = '''cp __envdir/REPOLINK/files_iso*.lst __envsub/
-'''
+read_files_repo_link3 = """cp __envdir/REPOLINK/files_iso*.lst __envsub/
+"""
+
 
 def rsync_fix_dest(distri, version, staging, use_staging_patterns):
-    if not staging: return ''
-    if use_staging_patterns: return '''
+    if not staging:
+        return ""
+    if use_staging_patterns:
+        return """
     staging_pattern=$flavor
     [ -z "${flavor_staging[$staging_pattern]}" ] || staging_pattern="${flavor_staging[$staging_pattern]}"
-    dest=${dest//$staging_pattern/Staging:__STAGING-$staging_pattern}'''
-    if version != 'Factory' and len(staging) == 1: return '''dest=${dest//$flavor/Staging:__STAGING-Staging-$flavor}'''
-    return '''dest=${dest//$flavor/Staging:__STAGING-$flavor}'''
+    dest=${dest//$staging_pattern/Staging:__STAGING-$staging_pattern}"""
+    if version != "Factory" and len(staging) == 1:
+        return """dest=${dest//$flavor/Staging:__STAGING-Staging-$flavor}"""
+    return """dest=${dest//$flavor/Staging:__STAGING-$flavor}"""
+
 
 def rsync_iso_fix_src(archs):
-    if 'armv7hl' in archs and not 'armv7l' in archs:
+    if "armv7hl" in archs and "armv7l" not in archs:
         return '[ -n "$src" ] || [ "$arch" != armv7hl ] || src=$(grep "$filter" __envsub/files_iso.lst | grep armv7l | head -n 1)'
-    return ''
+    return ""
+
 
 def rsync_commands(checksum):
     res = '''echo "rsync --timeout=3600 -tlp4 --specials PRODUCTISOPATH/${iso_folder[$flavor]}*$src /var/lib/openqa/factory/$asset_folder/$dest"'''
     if checksum:
-        res = res + '''
+        res = (
+            res
+            + '''
         echo "rsync --timeout=3600 -tlp4 --specials PRODUCTISOPATH/${iso_folder[$flavor]}*$srcSHAEXT /var/lib/openqa/factory/other/$destSHAEXT"'''
+        )
     return res
 
-rsync_iso = lambda distri, version, archs, staging, checksum, repo0folder, use_staging_patterns: '''
+
+def rsync_iso(
+    distri, version, archs, staging, checksum, repo0folder, use_staging_patterns
+):
+    return (
+        """
 archs=(ARCHITECTURS)
 
 for flavor in {FLAVORLIST,}; do
@@ -67,28 +83,38 @@ for flavor in {FLAVORLIST,}; do
         [ -z "${flavor_filter[$flavor]}" ] || filter=${flavor_filter[$flavor]}
         [[ ${norsync_filter[$filter]} != 1 ]] || continue
         src=$(grep "$filter" __envsub/files_iso.lst | grep $arch | head -n 1)
-        ''' + rsync_iso_fix_src(archs) + '''
+        """
+        + rsync_iso_fix_src(archs)
+        + """
         [ ! -z "$src" ] || continue
         dest=$src
-        ''' + rsync_fix_dest(distri, version, staging, use_staging_patterns) + r'''
+        """
+        + rsync_fix_dest(distri, version, staging, use_staging_patterns)
+        + r"""
         asset_folder=other
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
         [[ ! $dest =~ \.spdx\.json$  ]] || asset_folder=iso
         [[ ! $dest =~ \.tar$  ]] || asset_folder=iso
         [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx|xz)$ ]] || asset_folder=hdd
-        ''' + rsync_commands(checksum) + '''
+        """
+        + rsync_commands(checksum)
+        + """
         repo0folder=${dest%.iso}
         repo0folder=${repo0folder%.tar}
-        ''' + (repo0folder if repo0folder else "") + '''
+        """
+        + (repo0folder if repo0folder else "")
+        + """
         [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || echo "[ -d /var/lib/openqa/factory/repo/$repo0folder ] || {
     mkdir /var/lib/openqa/factory/repo/$repo0folder
     bsdtar xf /var/lib/openqa/factory/iso/$dest -C /var/lib/openqa/factory/repo/$repo0folder
 }"
         [ -z "FLAVORTOREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORTOREPOORS)$" ) -eq 0 ] || echo "cp -l /var/lib/openqa/factory/iso/$dest /var/lib/openqa/factory/repo/"
     done
-done'''
+done"""
+    )
 
-rsync_hdds = '''
+
+rsync_hdds = """
 archs=(ARCHITECTURS)
 
 for flavor in {FLAVORLIST,}; do
@@ -107,12 +133,14 @@ for flavor in {FLAVORLIST,}; do
             echo ""
         done < <(grep ${arch} __envsub/files_iso.lst | LANG=C.UTF-8 sort)
     done
-done'''
+done"""
+
 
 def pre_rsync_repo(repos):
-    return ''
+    return ""
 
-rsync_repo_buildid = '''
+
+rsync_repo_buildid = """
 [ ! -f __envsub/files_iso.lst ] || buildid=$(cat __envsub/files_iso.lst | grep -E 'FLAVORORS' | grep -o -E '(Build|Snapshot)[^-]*' | head -n 1)
 [ ! -f __envsub/files_iso.lst ] || test -n "$buildid" || buildid=$(cat __envsub/files_iso.lst | grep -o -E '(Build|Snapshot)[^-]*' | head -n 1)
 [ -z "__STAGING" ] || buildid=${buildid//Build/Build__STAGING.}
@@ -121,11 +149,14 @@ rsync_repo_buildid = '''
 
 buildid=${buildid/.install}
 buildid=${buildid/.iso}
-'''
+"""
 
-rsync_repo1 = '''
+rsync_repo1 = (
+    """
 echo '# REPOOWNLIST'
-''' + rsync_repo_buildid + '''
+"""
+    + rsync_repo_buildid
+    + """
 for repo in {REPOOWNLIST,}; do
     while read src; do
         [ ! -z "$src" ] || continue
@@ -133,9 +164,10 @@ for repo in {REPOOWNLIST,}; do
         destPrefix=${dest%-Media*}
         destSuffix=${dest#$destPrefix}
         dest=$destPrefix
-'''
+"""
+)
 
-rsync_repo2 = '''
+rsync_repo2 = """
         destPrefix=$dest
         repoDest=$destPrefix-$buildid$destSuffix
         repoCur=$destPrefix-CURRENT$destSuffix
@@ -144,9 +176,9 @@ rsync_repo2 = '''
         echo "rsync --timeout=3600 -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$repoCur/ /var/lib/openqa/factory/repo/$repoCur/ /var/lib/openqa/factory/repo/$repoDest/"
     done < <(grep $repo$additional_repo_suffix __envsub/files_repo.lst)
 done
-'''
+"""
 
-rsync_repodir1 = '''
+rsync_repodir1 = """
 archs=(ARCHITECTURREPO)
 
 
@@ -165,10 +197,11 @@ for arch in "${archs[@]}"; do
         destSuffix=${dest#$destPrefix}
         mid=''
         dest=$destPrefix$mid$destSuffix
-        [[ ! $src =~ .*\\.license ]] || [[ $dest == *license* ]] || dest=$dest.license'''
+        [[ ! $src =~ .*\\.license ]] || [[ $dest == *license* ]] || dest=$dest.license"""
+
 
 def rsync_repodir2():
-    return r'''
+    return r"""
         dest=${dest//-Media2/}
         Mdia=Media2
         [[ ! $src =~ .*\.license ]] || Mdia=Media2.license
@@ -176,9 +209,10 @@ def rsync_repodir2():
         echo rsync --timeout=3600 -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-debuginfo/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-debuginfo/ /var/lib/openqa/factory/repo/$dest-$buildid-debuginfo
     done < <(grep ${arch//i686/i586} __envsub/files_repo.lst | grep Media2 )
 done
-'''
+"""
 
-rsync_remodir_multiarch = '''
+
+rsync_remodir_multiarch = """
 buildid=$(grep -hEo 'Build[0-9]+(.[0-9]+)?' __envsub/Media1_*.lst 2>/dev/null | head -n 1)
 
 while read src; do
@@ -189,9 +223,9 @@ while read src; do
     echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials PRODUCTREPOPATH/$dest/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT
     echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/$dest-$buildid/
 done < <(cat __envsub/files_repo.lst | grep -v Debug | grep -v Source | grep -v .license )
-'''
+"""
 
-rsync_remodir_multiarch_debug = '''
+rsync_remodir_multiarch_debug = """
 while read src; do
     [ ! -z "$src" ] || continue
     dest=$src
@@ -200,46 +234,108 @@ while read src; do
     echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials  RSYNCFILTER PRODUCTREPOPATH/$dest/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/
     echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/$dest-$buildid/
 done < <(cat __envsub/files_repo.lst | grep Debug )
-'''
+"""
+
 
 def rsync_repomultiarch(destpath, debug, source):
     destpath = destpath.rstrip("/")
     dest = os.path.basename(destpath)
-    res = '''
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials PRODUCTREPOPATH/'''+ destpath +'''/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-CURRENT
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/''' + dest + '''-CURRENT/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-CURRENT/ /var/lib/openqa/factory/repo/''' + dest + '''-$buildid/
-'''
+    res = (
+        """
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials PRODUCTREPOPATH/"""
+        + destpath
+        + """/ /var/lib/openqa/factory/repo/fixed/"""
+        + dest
+        + """-CURRENT
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/"""
+        + dest
+        + """-CURRENT/ /var/lib/openqa/factory/repo/fixed/"""
+        + dest
+        + """-CURRENT/ /var/lib/openqa/factory/repo/"""
+        + dest
+        + """-$buildid/
+"""
+    )
 
     if debug:
-        debugfilter = "--include=" + debug + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
-        res = res + '''
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials ''' + debugfilter + ''' PRODUCTREPOPATH/'''+ destpath +'''-Debug/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Debug-CURRENT/
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Debug-CURRENT/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Debug-CURRENT/ /var/lib/openqa/factory/repo/''' + dest + '''-Debug-$buildid/'''
+        debugfilter = (
+            "--include="
+            + debug
+            + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
+        )
+        res = (
+            res
+            + """
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials """
+            + debugfilter
+            + """ PRODUCTREPOPATH/"""
+            + destpath
+            + """-Debug/ /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Debug-CURRENT/
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Debug-CURRENT/ /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Debug-CURRENT/ /var/lib/openqa/factory/repo/"""
+            + dest
+            + """-Debug-$buildid/"""
+        )
 
     if source:
-        sourcefilter = "--include=" + source + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
-        res = res + '''
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials ''' + sourcefilter + ''' PRODUCTREPOPATH/'''+ destpath +'''-Source/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Source-CURRENT/
-echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Source-CURRENT/ /var/lib/openqa/factory/repo/fixed/''' + dest + '''-Source-CURRENT/ /var/lib/openqa/factory/repo/''' + dest + '''-Source-$buildid/'''
+        sourcefilter = (
+            "--include="
+            + source
+            + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
+        )
+        res = (
+            res
+            + """
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials """
+            + sourcefilter
+            + """ PRODUCTREPOPATH/"""
+            + destpath
+            + """-Source/ /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Source-CURRENT/
+echo rsync --timeout=RSYNCTIMEOUT -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Source-CURRENT/ /var/lib/openqa/factory/repo/fixed/"""
+            + dest
+            + """-Source-CURRENT/ /var/lib/openqa/factory/repo/"""
+            + dest
+            + """-Source-$buildid/"""
+        )
 
     return res
 
-rsync_repodir1_dest = lambda dest: r'''
+
+def rsync_repodir1_dest(dest):
+    return (
+        r"""
 archs=(ARCHITECTURREPO)
 buildid=$(cat __envsub/files_iso.lst | grep -E 'FLAVORORS' | grep -o -E '(Build|Snapshot)[^-]*' | head -n 1)
 
 for arch in "${archs[@]}"; do
     while read src; do
         [ ! -z "$src" ] || continue
-        [[ ''' + dest + ''' =~ $arch ]] || [[ ''' + dest + ''' =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
-        dest=''' + dest + '''
-        [[ ! $src =~ .*\\.license ]] || dest=$dest.license'''
+        [[ """
+        + dest
+        + """ =~ $arch ]] || [[ """
+        + dest
+        + """ =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
+        dest="""
+        + dest
+        + """
+        [[ ! $src =~ .*\\.license ]] || dest=$dest.license"""
+    )
 
 
 def rsync_repodir1_dest_media0(dest, debug, source, folder):
     repo = os.path.basename(folder).lstrip("*")
-    xtra=""
-    res = r'''
+    xtra = ""
+    res = (
+        r"""
 
 # archs=(ARCHITECTURREPO)
 buildid=$(cat __envsub/files_iso.lst | grep -E 'FLAVORORS' | grep -o -E '(Build|Snapshot)[^-]*' | head -n 1)
@@ -247,89 +343,161 @@ buildid=$(cat __envsub/files_iso.lst | grep -E 'FLAVORORS' | grep -o -E '(Build|
 # for arch in "${archs[@]}"; do
     while read src; do
         [ ! -z "$src" ] || continue
-        [[ ''' + dest + ''' =~ $arch ]] || [[ ''' + dest + ''' =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
-        dest=''' + dest + '''
+        [[ """
+        + dest
+        + """ =~ $arch ]] || [[ """
+        + dest
+        + """ =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
+        dest="""
+        + dest
+        + """
         [[ ! $src =~ .*\\.license ]] || dest=$dest.license
-'''
+"""
+    )
 
-    res = res + '''
+    res = (
+        res
+        + """
         [[ $src != *"-Debug" ]] || {
-'''
+"""
+    )
     if debug:
-        xtra="--include=" + debug + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
-        res = res + '''
-            echo rsync --timeout=3600 -rtlp4 --delete --specials ''' + xtra + ''' PRODUCTREPOPATH/''' + folder + '''/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Debug/
+        xtra = (
+            "--include="
+            + debug
+            + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
+        )
+        res = (
+            res
+            + """
+            echo rsync --timeout=3600 -rtlp4 --delete --specials """
+            + xtra
+            + """ PRODUCTREPOPATH/"""
+            + folder
+            + """/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Debug/
             echo rsync --timeout=3600 -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Debug/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Debug/ /var/lib/openqa/factory/repo/$dest-$buildid-Debug
-'''
-    res = res + '''
+"""
+        )
+    res = (
+        res
+        + """
             continue
         }
-'''
+"""
+    )
 
-    res = res + '''
+    res = (
+        res
+        + """
         [[ $src != *"-Source" ]] || {
-'''
+"""
+    )
     if source:
-        xtra="--include=" + source + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
-        res = res + '''
-            echo rsync --timeout=3600 -rtlp4 --delete --specials ''' + xtra + ''' PRODUCTREPOPATH/''' + folder + '''/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Source/
+        xtra = (
+            "--include="
+            + source
+            + " --exclude={aarch64,armv7hl,armv6hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*"
+        )
+        res = (
+            res
+            + """
+            echo rsync --timeout=3600 -rtlp4 --delete --specials """
+            + xtra
+            + """ PRODUCTREPOPATH/"""
+            + folder
+            + """/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Source/
             echo rsync --timeout=3600 -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Source/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT-Source/ /var/lib/openqa/factory/repo/$dest-$buildid-Source
-'''
-    res = res + '''
+"""
+        )
+    res = (
+        res
+        + """
             continue
         }
-'''
+"""
+    )
 
-    res = res + '''
-        echo rsync --timeout=3600 -rtlp4 --delete --specials PRODUCTREPOPATH/''' + folder + '''/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/
+    res = (
+        res
+        + """
+        echo rsync --timeout=3600 -rtlp4 --delete --specials PRODUCTREPOPATH/"""
+        + folder
+        + """/$src/  /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/
         echo rsync --timeout=3600 -rtlp4 --delete --specials --link-dest /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/fixed/$dest-CURRENT/ /var/lib/openqa/factory/repo/$dest-$buildid
-    done < <(LANG=C.UTF-8 sort __envsub/files_repo_''' + repo + '''.lst )
+    done < <(LANG=C.UTF-8 sort __envsub/files_repo_"""
+        + repo
+        + """.lst )
 # done
-'''
+"""
+    )
 
     return res
 
 
 def openqa_call_fix_destiso(distri, version, staging):
     if not staging:
-        return ''
-    if (version == 'Factory' or len(staging)>1):
-        return '''destiso=${iso//$flavor/Staging:__STAGING-$flavor}
-        flavor=Staging-$flavor'''
-    return '''version=${version}:S:__STAGING
+        return ""
+    if version == "Factory" or len(staging) > 1:
+        return """destiso=${iso//$flavor/Staging:__STAGING-$flavor}
+        flavor=Staging-$flavor"""
+    return """version=${version}:S:__STAGING
         destiso=${iso//$flavor/Staging:__STAGING-Staging-$flavor}
-        flavor=Staging-$flavor'''
+        flavor=Staging-$flavor"""
+
 
 def openqa_call_start_fix_iso(archs):
-    if 'armv7hl' in archs and not 'armv7l' in archs:
+    if "armv7hl" in archs and "armv7l" not in archs:
         return '[ -n "$iso" ] || [ "$arch" != armv7hl ] || iso=$(grep "$filter" __envsub/files_iso.lst | grep armv7l | head -n 1)'
-    return ''
+    return ""
+
 
 def openqa_call_news(news, news_archs):
     if not news:
-        return ''
-    news_str = '''[[ ! "$flavor" =~ ''' + news + ''' ]]'''
+        return ""
+    news_str = """[[ ! "$flavor" =~ """ + news + """ ]]"""
     if news_archs:
-        news_str += ''' || [ "$arch" != ''' + news_archs + ''' ]'''
+        news_str += """ || [ "$arch" != """ + news_archs + """ ]"""
     return news_str + ''' || news["$flavor"]="$destiso"'''
+
 
 def openqa_call_start_distri(flavor_distri):
     if flavor_distri:
-        return '''distri=DISTRIVALUE
-        [ -z "${flavor_distri[$flavor]}" ] || distri=${flavor_distri[$flavor]}'''
-    return 'distri=DISTRIVALUE'
+        return """distri=DISTRIVALUE
+        [ -z "${flavor_distri[$flavor]}" ] || distri=${flavor_distri[$flavor]}"""
+    return "distri=DISTRIVALUE"
+
 
 def openqa_call_start_meta_variables(meta_variables):
     if not meta_variables:
-        return 'VERSION=$version\"'
+        return 'VERSION=$version"'
 
-    return '''VERSION=$version \\\\
- ''' + meta_variables + '\"'
+    return (
+        """VERSION=$version \\\\
+ """
+        + meta_variables
+        + '"'
+    )
+
 
 def pre_openqa_call_start(repos):
-    return ''
+    return ""
 
-openqa_call_start = lambda distri, version, archs, staging, news, news_archs, flavor_distri, meta_variables, assets_flavor, repo0folder, openqa_cli: '''
+
+def openqa_call_start(
+    distri,
+    version,
+    archs,
+    staging,
+    news,
+    news_archs,
+    flavor_distri,
+    meta_variables,
+    assets_flavor,
+    repo0folder,
+    openqa_cli,
+):
+    return (
+        """
 archs=(ARCHITECTURS)
 [ ! -f __envsub/files_repo.lst ] || ! grep -q -- "-POOL-" __envsub/files_repo.lst || additional_repo_suffix=-POOL
 
@@ -338,18 +506,26 @@ isoflavor=REALISOFLAVOR
 for flavor in {FLAVORALIASLIST,}; do
     for arch in "${archs[@]}"; do
         filter=$flavor
-        ''' + openqa_call_start_distri(flavor_distri) + '''
+        """
+        + openqa_call_start_distri(flavor_distri)
+        + """
         [ -z "${flavor_filter[$flavor]}" ] || filter=${flavor_filter[$flavor]}
         [ $filter != Appliance ] || filter="qcow2"
         [ -z "$isoflavor" ] || filter=${isoflavor}
         version=VERSIONVALUE
         if [ -z "${norsync_filter[$flavor]}" ] || [ -z $build1 ]; then {
         iso=$(grep "$filter" __envsub/files_iso.lst 2>/dev/null | grep $arch | head -n 1)
-        ''' + openqa_call_start_fix_iso(archs) + r'''
+        """
+        + openqa_call_start_fix_iso(archs)
+        + r'''
         build=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | tail -n 1) || :
         buildex=$(echo $iso | grep -o -E '(Build|Snapshot)[^-]*') || :
-        [ -n "$iso" ] || [ "$flavor" != "''' + assets_flavor + r'''" ] || build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)
-        [ -n "$iso" ] || [ "$flavor" != "''' + assets_flavor + r'''" ] || buildex=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | head -n 1)
+        [ -n "$iso" ] || [ "$flavor" != "'''
+        + assets_flavor
+        + r'''" ] || build=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*' | head -n 1)
+        [ -n "$iso" ] || [ "$flavor" != "'''
+        + assets_flavor
+        + r"""" ] || buildex=$(grep -o -E '(Build|Snapshot)[^-]*' __envsub/files_asset.lst | head -n 1)
         [ -n "$iso$build" ] || build=$(grep -h -o -E '(Build|Snapshot)[^-]*' __envsub/Media1*.lst 2>/dev/null | head -n 1 | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*')|| :
         [ -n "$build" ] || [ "FIXEDISO" != 1 ] || build=$(grep -h -o -E '(Build|Snapshot)[^-]*' __envsub/Media1*.lst 2>/dev/null | head -n 1 | grep -o -E '[0-9]\.?[0-9]+(\.[0-9]+)*')|| :
         [ -n "$build"  ] || continue
@@ -360,60 +536,90 @@ for flavor in {FLAVORALIASLIST,}; do
         build1=$build
         destiso=$iso
         [ -z "__STAGING" ] || build1=__STAGING.$build
-        ''' + openqa_call_fix_destiso(distri, version, staging) + '''
+        """
+        + openqa_call_fix_destiso(distri, version, staging)
+        + """
         repo0folder=${destiso%.iso}
         repo0folder=${repo0folder%.tar}
-        ''' + (repo0folder if repo0folder else "") + '''
+        """
+        + (repo0folder if repo0folder else "")
+        + """
         [ "$arch" != . ] || arch=x86_64
-        ''' + openqa_call_news(news, news_archs) + '''
+        """
+        + openqa_call_news(news, news_archs)
+        + '''
         }
         fi
         # test "$destiso" != "" || continue
-        echo "''' + openqa_cli + ''' \\\\\"
+        echo "'''
+        + openqa_cli
+        + """ \\\\\"
 (
  echo \" DISTRI=$distri \\\\
  ARCH=$arch \\\\
  BUILD=$build1 \\\\
- ''' + openqa_call_start_meta_variables(meta_variables)
+ """
+        + openqa_call_start_meta_variables(meta_variables)
+    )
 
-openqa_call_legacy_builds_link=''
 
-openqa_call_legacy_builds=''
+openqa_call_legacy_builds_link = ""
+
+openqa_call_legacy_builds = ""
+
 
 def openqa_call_start_iso(checksum):
     if checksum:
         return r''' [ -z "$destiso" ] || echo " ISO=${destiso} \\
  CHECKSUM_ISO=\$(cut -b-SHALEN /var/lib/openqa/factory/other/${destiso}SHAEXT | grep -E '[0-9a-f]{5,40}' | head -n1) \\
  ASSET_SHAVALUE=${destiso}SHAEXT \\"'''
-    return ''' [ -z "$destiso]" || echo \" ISO=${destiso} \\\\
- ASSET_SHAVALUE=${destiso}SHAEXT \\\\\"'''
+    return """ [ -z "$destiso]" || echo \" ISO=${destiso} \\\\
+ ASSET_SHAVALUE=${destiso}SHAEXT \\\\\""""
+
 
 def openqa_call_start_ex1(checksum, tag):
-    res = tag + '=${destiso} \\\\'
+    res = tag + "=${destiso} \\\\"
     if checksum:
-        res += '''
- CHECKSUM_''' + tag + r'''=\$(cut -b-SHALEN /var/lib/openqa/factory/other/${destiso}SHAEXT | grep -E '[0-9a-f]{5,40}' | head -n1) \\
- ASSET_SHAVALUE=${destiso}SHAEXT \\'''
+        res += (
+            """
+ CHECKSUM_"""
+            + tag
+            + r"""=\$(cut -b-SHALEN /var/lib/openqa/factory/other/${destiso}SHAEXT | grep -E '[0-9a-f]{5,40}' | head -n1) \\
+ ASSET_SHAVALUE=${destiso}SHAEXT \\"""
+        )
     return res
 
 
 def openqa_call_start_ex(checksum):
-    return r''' if [[ ${norsync_filter[$filter]} == 1 ]]; then
+    return (
+        r""" if [[ ${norsync_filter[$filter]} == 1 ]]; then
    :
  elif [[ $destiso =~ \.iso$ ]]; then
-   echo " ''' + openqa_call_start_ex1(checksum, 'ISO')  + r'''"
+   echo " """
+        + openqa_call_start_ex1(checksum, "ISO")
+        + r""""
  elif [[ $destiso =~ \.spdx.json$ ]]; then
-   echo " ''' + openqa_call_start_ex1(checksum, 'ISO')  + r'''"
+   echo " """
+        + openqa_call_start_ex1(checksum, "ISO")
+        + r""""
  elif [[ $destiso =~ \.tar$ ]]; then
-   echo " ''' + openqa_call_start_ex1(checksum, 'ISO')  + r'''"
+   echo " """
+        + openqa_call_start_ex1(checksum, "ISO")
+        + r""""
  elif [[ $destiso =~ \.(hdd|qcow2|raw|raw\.xz|raw\.gz|vhdx\.xz|vmdk|vmdk\.xz)$ ]]; then
-   echo " ''' + openqa_call_start_ex1(checksum, 'HDD_1')  + r'''"
+   echo " """
+        + openqa_call_start_ex1(checksum, "HDD_1")
+        + r""""
  elif [ -n "$destiso" ]; then
-   echo " ''' + openqa_call_start_ex1(checksum, 'ASSET_1')  + r'''"
+   echo " """
+        + openqa_call_start_ex1(checksum, "ASSET_1")
+        + r""""
  fi
-'''
+"""
+    )
 
-openqa_call_start_hdds=r'''
+
+openqa_call_start_hdds = r"""
  i=1
  while read src; do
      folder=""
@@ -433,56 +639,64 @@ openqa_call_start_hdds=r'''
          echo " CHECKSUM_HDD_$n=\$(cut -b-SHALEN /var/lib/openqa/factory/other/$srcSHAEXT | grep -E '[0-9a-f]{5,40}' | head -n1) \\"
      fi
  done < <(grep ${arch} __envsub/files_iso.lst | LANG=C.UTF-8 sort)
-'''
+"""
+
 
 # if MIRROREPO is set - expressions for FLAVORASREPOORS will evaluate to false
 def openqa_call_repo0():
-    return ''' [ -z "FLAVORASREPOORSMIRRORREPO" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) == 0"MIRRORREPO" ] || {
+    return """ [ -z "FLAVORASREPOORSMIRRORREPO" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) == 0"MIRRORREPO" ] || {
     echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\
  SUSEMIRROR=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  INST_INSTALL_URL=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  FULLURL=1 \\\\"
-    }'''
+    }"""
+
 
 def openqa_call_repo_unconditional():
-    return ''' echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\
+    return """ echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\
  SUSEMIRROR=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  INST_INSTALL_URL=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  FULLURL=1 \\\\"
-    '''
+    """
+
 
 openqa_call_repo0a = ' [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || '
 
 openqa_call_repo0b = ' echo " REPO_0=REPO0_ISO \\\\"'
 
-openqa_call_repo5 = '''    destRepo=${destiso%.iso}
+openqa_call_repo5 = """    destRepo=${destiso%.iso}
   filter1=${filter//-DVD/-POOL}
   destRepo=${destRepo//$filter/$filter1}
   echo " REPO_5=$destRepo \\\\
  REPO_6=$destRepo.license \\\\
  REPO_REPOALIAS=$destRepo \\\\"
-'''
+"""
+
 
 def openqa_call_repot_part1():
-    return '''[ -z "__STAGING" ] || repo=${repo//Module/Staging:__STAGING-Module}
-                [ -z "__STAGING" ] || repo=${repo//Product/Staging:__STAGING-Product}'''
+    return """[ -z "__STAGING" ] || repo=${repo//Module/Staging:__STAGING-Module}
+                [ -z "__STAGING" ] || repo=${repo//Product/Staging:__STAGING-Product}"""
+
 
 def openqa_call_repot_part2():
-    return 'repoDest=$repoPrefix-Build$build$repoSuffix'
+    return "repoDest=$repoPrefix-Build$build$repoSuffix"
+
 
 def openqa_call_repot_part3():
-    return '''[[ $repoDest != *Media2* ]] || repoKey=${repoKey}_DEBUG
-                [[ $repoDest != *Media3* ]] || repoKey=${repoKey}_SOURCE'''
+    return """[[ $repoDest != *Media2* ]] || repoKey=${repoKey}_DEBUG
+                [[ $repoDest != *Media3* ]] || repoKey=${repoKey}_SOURCE"""
+
 
 def openqa_call_build_id_from_iso1(build_id_from_iso):
     if not build_id_from_iso:
         return ""
-    return r'''build2=$(grep $repot __envsub/files_iso_buildid.lst | grep $arch | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]+.?[0-9]+(\.[0-9]+)?' | head -n 1)
-                [ -z "$build2" ] || build1=$build2'''
+    return r"""build2=$(grep $repot __envsub/files_iso_buildid.lst | grep $arch | grep -o -E '(Build|Snapshot)[^-]*' | grep -o -E '[0-9]+.?[0-9]+(\.[0-9]+)?' | head -n 1)
+                [ -z "$build2" ] || build1=$build2"""
+
 
 def openqa_call_build_id_from_iso2(build_id_from_iso):
     if not build_id_from_iso:
@@ -490,56 +704,88 @@ def openqa_call_build_id_from_iso2(build_id_from_iso):
     return r'''[ "$repoKey" != LIVE_PATCHING ] || repoKey=LIVE
                 [[ $repoDest != *Media1* ]] || [[ $repo =~ license ]] || [ -z "$build2" ] || echo " BUILD_$repoKey=$build2 \\\\"'''
 
-def openqa_call_extra(repos):
-    return ''
 
-openqa_call_repot = lambda build_id_from_iso, repos: '''
+def openqa_call_extra(repos):
+    return ""
+
+
+def openqa_call_repot(build_id_from_iso, repos):
+    return (
+        """
         for repot in {REPOLIST,}; do
             while read repo; do
-                ''' + openqa_call_repot_part1() + '''
+                """
+        + openqa_call_repot_part1()
+        + """
                 repoPrefix=${repo%-Media*}
                 repoSuffix=${repo#$repoPrefix}
-                ''' + openqa_call_build_id_from_iso1(build_id_from_iso) + '''
-                ''' + openqa_call_repot_part2() + '''
+                """
+        + openqa_call_build_id_from_iso1(build_id_from_iso)
+        + """
+                """
+        + openqa_call_repot_part2()
+        + """
                 repoKey=${repot}
                 repoKey=${repoKey^^}
                 repoKey=${repoKey//-/_}
                 repoKey=${repoKey//./_}
                 repoKey=${repoKey//$/}
                 echo " REPO_$i=$repoDest \\\\"
-                ''' + openqa_call_repot_part3() + '''
-                ''' + openqa_call_build_id_from_iso2(build_id_from_iso) + '''
+                """
+        + openqa_call_repot_part3()
+        + """
+                """
+        + openqa_call_build_id_from_iso2(build_id_from_iso)
+        + """
                 [[ $repo =~ license ]] || echo " REPO_REPOPREFIX$repoKey=$repoDest \\\\"
-                ''' + openqa_call_extra(repos) + '''
+                """
+        + openqa_call_extra(repos)
+        + """
                 : $((i++))
             done < <(grep $repot$additional_repo_suffix __envsub/files_repo.lst | grep REPOTYPE | grep $arch | LANG=C.UTF-8 sort)
-        done'''
+        done"""
+    )
+
 
 def openqa_call_repot1_debugsource(debug, source):
-    res = '''[[ $src != *Media2* ]] || repoKey=${repoKey}_DEBUGINFO
+    res = """[[ $src != *Media2* ]] || repoKey=${repoKey}_DEBUGINFO
             [[ $src != *Media2* ]] || dest=$dest-debuginfo
             [[ $src != *Media3* ]] || repoKey=${repoKey}_SOURCE
-            [[ $src != *Media3* ]] || dest=$dest-source'''
+            [[ $src != *Media3* ]] || dest=$dest-source"""
     if debug:
-        res = res + '''
+        res = (
+            res
+            + """
             [[ $src != *-Debug ]] || repoKey=${repoKey}_DEBUG
-            [[ $src != *-Debug ]] || [[ $dest == *Debug* ]] || dest=$dest-Debug'''
+            [[ $src != *-Debug ]] || [[ $dest == *Debug* ]] || dest=$dest-Debug"""
+        )
     else:
-        res = res + '''
-            [[ $src != *-Debug ]] || continue'''
+        res = (
+            res
+            + """
+            [[ $src != *-Debug ]] || continue"""
+        )
 
     if source:
-        res = res + '''
+        res = (
+            res
+            + """
             [[ $src != *-Source ]] || repoKey=${repoKey}_SOURCE
-            [[ $src != *-Source ]] || [[ $dest == *Source* ]] || dest=$dest-Source'''
+            [[ $src != *-Source ]] || [[ $dest == *Source* ]] || dest=$dest-Source"""
+        )
     else:
-        res = res + '''
-            [[ $src != *-Source ]] || continue'''
+        res = (
+            res
+            + """
+            [[ $src != *-Source ]] || continue"""
+        )
 
     return res
 
 
-openqa_call_repot1 = lambda debug, source: '''
+def openqa_call_repot1(debug, source):
+    return (
+        """
         while read src; do
             dest=$src
             dest=${dest%-Build*}
@@ -559,53 +805,77 @@ openqa_call_repot1 = lambda debug, source: '''
             repoKey=${repoKey//-/_}
             repoKey=${repoKey//./_}
             repoKey=${repoKey//$/}
-            ''' + openqa_call_repot1_debugsource(debug, source) + '''
+            """
+        + openqa_call_repot1_debugsource(debug, source)
+        + """
             dest=${dest//-Media1/}
             dest=${dest//-Media2/}
             dest=${dest//-Media3/}
-'''
+"""
+    )
 
-openqa_call_repot2 = '''
+
+openqa_call_repot2 = """
             echo " REPO_$i=$dest \\\\"
             [[ $src =~ license ]] || echo " REPO_$repoKey=$dest \\\\"
             [[ ! $repoKey =~ _DEBUGINFO ]] || [ -z "DEBUG_PACKAGES" ] || echo " REPO_${{repoKey}}_PACKAGES='DEBUG_PACKAGES' \\\\"
             [[ $repoKey != *_DEBUG ]]      || [ -z "DEBUG_PACKAGES" ] || echo " REPO_${{repoKey}}_PACKAGES='DEBUG_PACKAGES' \\\\"
             [[ ! $repoKey =~ _SOURCE ]] || [ -z "SOURCE_PACKAGES" ] || echo " REPO_${{repoKey}}_PACKAGES='SOURCE_PACKAGES' \\\\"
             : $((i++))
-        done < <(grep ${{arch//i686/i586}} __envsub/files_repo.lst {} | LANG=C.UTF-8 sort)'''
+        done < <(grep ${{arch//i686/i586}} __envsub/files_repo.lst {} | LANG=C.UTF-8 sort)"""
 
 
-openqa_call_repot1_dest = lambda dest, debug, source: '''
+def openqa_call_repot1_dest(dest, debug, source):
+    return (
+        """
         while read src; do
-            [[ ''' + dest + ''' =~ $arch ]] || [[ ''' + dest + ''' =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
-            dest=''' + dest + r'''
+            [[ """
+        + dest
+        + """ =~ $arch ]] || [[ """
+        + dest
+        + """ =~ ${arch//i686/i586} ]] || [[ "ARCHITECTURREPO" == . ]] || break
+            dest="""
+        + dest
+        + r"""
             [[ ! $src =~ .*\.license ]] || dest=$dest.license
             dest=$dest-$buildex
             repoKey=REPOKEY
-            ''' + openqa_call_repot1_debugsource(debug, source) + '''
+            """
+        + openqa_call_repot1_debugsource(debug, source)
+        + """
             repoKey=${repoKey^^}
             repoKey=${repoKey//-/_}
             repoKey=${repoKey//./_}
             repoKey=${repoKey//$/}
-'''
+"""
+    )
+
 
 def openqa_call_news_end(distri, news, news_arch):
     if not news:
-        return ''
-    suff = ''
-    if news_arch and news_arch != 'x86_64':
-        suff = '-' + news_arch
-    folder='${n,,}'
-    if distri != 'microos':
-        folder = 'opensuse'
-    return '''for n in "${!news[@]}"; do
-    folder=''' + folder + '''
-    folder=${folder%-dvd}''' + suff + '''
+        return ""
+    suff = ""
+    if news_arch and news_arch != "x86_64":
+        suff = "-" + news_arch
+    folder = "${n,,}"
+    if distri != "microos":
+        folder = "opensuse"
+    return (
+        """for n in "${!news[@]}"; do
+    folder="""
+        + folder
+        + """
+    folder=${folder%-dvd}"""
+        + suff
+        + """
     echo  /var/lib/openqa/osc-plugin-factory/factory-package-news/factory-package-news.py save --dir /var/lib/snapshot-changes/$folder/VERSIONVALUE --snapshot $build1 /var/lib/openqa/factory/iso/${news[$n]}
-done'''
+done"""
+    )
+
 
 def openqa_call_end(version):
-    if version == 'Factory': return '''
+    if version == "Factory":
+        return """
         [ $flavor != MicroOS-DVD ] || flavor=DVD
         [ $flavor != Staging-MicroOS-DVD ] || flavor=Staging-DVD
         echo " FLAVOR=${flavor//Tumbleweed-/} \\\\"
@@ -613,17 +883,19 @@ def openqa_call_end(version):
         echo ""
     done
 done
-'''
-    return '''
+"""
+    return """
         echo " FLAVOR=$flavor \\\\"
 ) | LANG=C.UTF-8 sort
         echo ""
     done
 done
-'''
+"""
+
 
 def media2_name():
-    return 'debug'
+    return "debug"
+
 
 def media3_name():
-    return 'source'
+    return "source"

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1,10 +1,9 @@
 import sys
 import os
 import re
-from subprocess import check_output, CalledProcessError, STDOUT
+from subprocess import check_output, CalledProcessError
 import argparse
 import copy
-from contextlib import suppress
 from xml.etree import ElementTree
 from collections import defaultdict
 
@@ -30,7 +29,7 @@ class ActionGenerator:
                 pp = os.path.join(pp, productpath)
         self.productpath = pp
         self.archs = "aarch64 armv7l armv7hl ppc64le riscv64 s390x x86_64"
-        self.media1 = 1
+        self.media1 = "1"
         self.sha = "256"
 
     def staging(self):
@@ -193,8 +192,8 @@ class ActionBatch:
         self.meta_variables = "_OBSOLETE=1"
         if self.ag.brand != "obs" and not self.ag.staging():
             self.meta_variables = "_DEPRIORITIZEBUILD=1"
-        self.offset = 1
-        self.media1 = 1
+        self.offset = "1"
+        self.media1 = "1"
         self.sha = "256"
         self.realisoflavor = ""
 
@@ -237,15 +236,15 @@ class ActionBatch:
         extra9=None,
         extra10=None,
     ):
-        if extra1 != None and extra2 != None:
+        if extra1 is not None and extra2 is not None:
             s = s.replace(extra1, extra2)
-            if extra3 != None and extra4 != None:
+            if extra3 is not None and extra4 is not None:
                 s = s.replace(extra3, extra4)
-                if extra5 != None and extra6 != None:
+                if extra5 is not None and extra6 is not None:
                     s = s.replace(extra5, extra6)
-                    if extra7 != None and extra8 != None:
+                    if extra7 is not None and extra8 is not None:
                         s = s.replace(extra7, extra8)
-                        if extra9 != None and extra10 != None:
+                        if extra9 is not None and extra10 is not None:
                             s = s.replace(extra9, extra10)
         xtrapath = ""
         if self.folder:
@@ -267,7 +266,9 @@ class ActionBatch:
         elif self.ag.staging() and self.ag.version == "Factory":
             s = s.replace("VERSIONVALUE", "Staging:" + self.ag.staging())
         else:
-            s = s.replace("VERSIONVALUE", self.ag.version.replace("Factory", "Tumbleweed"))
+            s = s.replace(
+                "VERSIONVALUE", self.ag.version.replace("Factory", "Tumbleweed")
+            )
         s = s.replace("DISTRIVALUE", self.distri)
         s = s.replace("__STAGING", self.ag.staging())
         s = s.replace("ARCHITECTURS", self.archs)
@@ -275,7 +276,9 @@ class ActionBatch:
             s = s.replace("ARCHITECTURREPO", self.archs_repo)
         else:
             s = s.replace("ARCHITECTURREPO", self.archs)
-        s = s.replace("ARCHORS", self.archs.replace(" ", "|").replace("armv7hl", "armv7hl|armv7l"))
+        s = s.replace(
+            "ARCHORS", self.archs.replace(" ", "|").replace("armv7hl", "armv7hl|armv7l")
+        )
         s = s.replace("SUBFOLDER", self.subfolder)
 
         if self.flavors or self.flavor_aliases_flavor:
@@ -284,13 +287,27 @@ class ActionBatch:
             aliases.extend(self.flavor_aliases_flavor)
             s = s.replace("FLAVORORS", "|".join(self.flavors))
             s = s.replace("FLAVORALIASLIST", ",".join(aliases))
-            s = s.replace("FLAVORASREPOORS", "|".join([f for f in self.flavors if self.iso_extract_as_repo.get(f, 0)]))
-            s = s.replace("FLAVORTOREPOORS", "|".join([f for f in self.flavors if self.ln_iso_to_repo.get(f, 0)]))
+            s = s.replace(
+                "FLAVORASREPOORS",
+                "|".join(
+                    [f for f in self.flavors if self.iso_extract_as_repo.get(f, 0)]
+                ),
+            )
+            s = s.replace(
+                "FLAVORTOREPOORS",
+                "|".join([f for f in self.flavors if self.ln_iso_to_repo.get(f, 0)]),
+            )
 
-        if self.repos or (self.repolink and not "/" in self.repolink):
+        if self.repos or (self.repolink and "/" not in self.repolink):
             repos = self.repos.copy()
             s = s.replace(
-                "REPOOWNLIST", ",".join([m.attrib["name"] if "name" in m.attrib else m.tag for m in repos.copy()])
+                "REPOOWNLIST",
+                ",".join(
+                    [
+                        m.attrib["name"] if "name" in m.attrib else m.tag
+                        for m in repos.copy()
+                    ]
+                ),
             )
             if self.repolink:
                 repos.extend(self.ag.batch_by_name(self.repolink).repos)
@@ -305,10 +322,23 @@ class ActionBatch:
                     ),
                 )
             else:
-                s = s.replace("REPOLIST", ",".join([m.attrib["name"] if "name" in m.attrib else m.tag for m in repos]))
-            s = s.replace("REPOORS", "|".join([m.attrib["name"] if "name" in m.attrib else m.tag for m in repos]))
+                s = s.replace(
+                    "REPOLIST",
+                    ",".join(
+                        [
+                            m.attrib["name"] if "name" in m.attrib else m.tag
+                            for m in repos
+                        ]
+                    ),
+                )
+            s = s.replace(
+                "REPOORS",
+                "|".join(
+                    [m.attrib["name"] if "name" in m.attrib else m.tag for m in repos]
+                ),
+            )
         mirror_repo = self.mirror_repo
-        if not mirror_repo and self.repolink and not "/" in self.repolink:
+        if not mirror_repo and self.repolink and "/" not in self.repolink:
             self.mirror_repo = self.ag.batch_by_name(self.repolink).mirror_repo
         s = s.replace("MIRRORREPO", self.mirror_repo)
         if self.ag.domain:
@@ -489,10 +519,10 @@ class ActionBatch:
             with open(filename, "r") as f:
                 line1 = f.readline()
                 line2 = f.readline()
-                if line1 and not "GENERATED" in line1:
+                if line1 and "GENERATED" not in line1:
                     if not line1.lstrip().startswith("#"):
                         custom = 1
-                    elif line2 and not "GENERATED" in line2:
+                    elif line2 and "GENERATED" not in line2:
                         custom = 1
         if custom:
             print("Will not overwrite custom file: " + filename, file=sys.stderr)
@@ -515,12 +545,27 @@ class ActionBatch:
             )
         body = gen
         if repodir.attrib.get("source", ""):
-            body = body + """
-""" + gen.replace("Media1", "Media2")
+            body = (
+                body
+                + """
+"""
+                + gen.replace("Media1", "Media2")
+            )
         if repodir.attrib.get("debug", ""):
-            body = body + """
-""" + gen.replace("Media1", "Media3")
-        self.p('echo "' + body + '" > __envsub/files_repo_' + repodir.attrib["folder"] + ".lst", f)
+            body = (
+                body
+                + """
+"""
+                + gen.replace("Media1", "Media3")
+            )
+        self.p(
+            'echo "'
+            + body
+            + '" > __envsub/files_repo_'
+            + repodir.attrib["folder"]
+            + ".lst",
+            f,
+        )
 
     def gen_read_files(self, f):
         self.p(cfg.header, f, "set -e", "set -eo pipefail")
@@ -560,9 +605,23 @@ class ActionBatch:
                     )
         if not self.isos and not self.hdds:
             for asset in self.assets:
-                self.p(cfg.read_files_hdd, f, "FOLDER", self.asset_folders.get(asset, ""), "ISOMASK", asset)
+                self.p(
+                    cfg.read_files_hdd,
+                    f,
+                    "FOLDER",
+                    self.asset_folders.get(asset, ""),
+                    "ISOMASK",
+                    asset,
+                )
         if self.iso_5:
-            self.p(cfg.read_files_iso, f, "FOLDER", self.iso_folder.get(self.iso_5, ""), "SRCISO", self.iso_5)
+            self.p(
+                cfg.read_files_iso,
+                f,
+                "FOLDER",
+                self.iso_folder.get(self.iso_5, ""),
+                "SRCISO",
+                self.iso_5,
+            )
         elif self.isos:
             # if isos don't belong to custom folder - just read them all with single command
             if not self.iso_folder and self.media1 != "0":
@@ -613,7 +672,13 @@ class ActionBatch:
             self.p(cfg.read_files_repo_link, f)
         if self.repolink and self.build_id_from_iso:
             self.p(cfg.read_files_repo_link2, f)
-        if self.repolink and not self.isos and not self.iso_5 and not self.hdds and not self.assets:
+        if (
+            self.repolink
+            and not self.isos
+            and not self.iso_5
+            and not self.hdds
+            and not self.assets
+        ):
             self.p(cfg.read_files_repo_link3, f)
         if self.repos:
             if self.media1 == "0":
@@ -648,7 +713,10 @@ class ActionBatch:
                     "|".join(
                         [
                             m.attrib["name"] if "name" in m.attrib else m.tag
-                            for m in filter(lambda x: x.attrib.get(cfg.media2_name(), ""), self.repos)
+                            for m in filter(
+                                lambda x: x.attrib.get(cfg.media2_name(), ""),
+                                self.repos,
+                            )
                         ]
                     ),
                 )
@@ -662,7 +730,10 @@ class ActionBatch:
                     "|".join(
                         [
                             m.attrib["name"] if "name" in m.attrib else m.tag
-                            for m in filter(lambda x: x.attrib.get(cfg.media3_name(), ""), self.repos)
+                            for m in filter(
+                                lambda x: x.attrib.get(cfg.media3_name(), ""),
+                                self.repos,
+                            )
                         ]
                     ),
                 )
@@ -683,9 +754,23 @@ class ActionBatch:
                 if self.folder:
                     selffolder = "/" + self.folder
                 if "/" in self.folder or "/" in repodir.attrib["folder"]:
-                    repopath = self.ag.productpath + selffolder + "/*" + repodir.attrib["folder"] + "*" + suffix
+                    repopath = (
+                        self.ag.productpath
+                        + selffolder
+                        + "/*"
+                        + repodir.attrib["folder"]
+                        + "*"
+                        + suffix
+                    )
                 else:
-                    repopath = self.ag.productrepopath() + selffolder + "/*" + repodir.attrib["folder"] + "*" + suffix
+                    repopath = (
+                        self.ag.productrepopath()
+                        + selffolder
+                        + "/*"
+                        + repodir.attrib["folder"]
+                        + "*"
+                        + suffix
+                    )
 
                 args = (
                     cfg.read_files_repo,
@@ -695,7 +780,9 @@ class ActionBatch:
                     "REPOORS",
                     "",
                     "files_repo.lst",
-                    "files_repo_{}.lst".format(os.path.basename(repodir.attrib["folder"]).strip("*")),
+                    "files_repo_{}.lst".format(
+                        os.path.basename(repodir.attrib["folder"]).strip("*")
+                    ),
                     "ARCHORS",
                     archs.replace(" ", "|").replace("armv7hl", "armv7hl|armv7l"),
                 )
@@ -705,7 +792,11 @@ class ActionBatch:
 
         # let's sync media.1/media to be able verify build_id
         if "ToTest" or "LEO" in self.ag.envdir or self.version_from_media:
-            if "Leap" in self.ag.envdir or "Jump" in self.ag.envdir or self.version_from_media:
+            if (
+                "Leap" in self.ag.envdir
+                or "Jump" in self.ag.envdir
+                or self.version_from_media
+            ):
                 for repodir in self.repodirs:
                     archs = self.archs
                     if not archs:
@@ -713,10 +804,14 @@ class ActionBatch:
                     wild = ""
                     arch = ""
                     done = ""
-                    if archs and not " " in archs:
+                    if archs and " " not in archs:
                         wild = "*" + archs + "*"
 
-                    if " " in archs and self.repodirs and "1" != repodir.attrib.get("multiarch", ""):
+                    if (
+                        " " in archs
+                        and self.repodirs
+                        and "1" != repodir.attrib.get("multiarch", "")
+                    ):
                         self.p("for arch in {}; do".format(archs), f)
                         wild = "*$arch*"
                         arch = "$arch"
@@ -726,9 +821,21 @@ class ActionBatch:
                     if self.folder:
                         selffolder = "/" + self.folder
                     if "/" in self.folder or "/" in repodir.attrib["folder"]:
-                        repopath = self.ag.productpath + selffolder + "/*" + repodir.attrib["folder"] + wild
+                        repopath = (
+                            self.ag.productpath
+                            + selffolder
+                            + "/*"
+                            + repodir.attrib["folder"]
+                            + wild
+                        )
                     else:
-                        repopath = self.ag.productrepopath() + selffolder + "/*" + repodir.attrib["folder"] + wild
+                        repopath = (
+                            self.ag.productrepopath()
+                            + selffolder
+                            + "/*"
+                            + repodir.attrib["folder"]
+                            + wild
+                        )
 
                     Media1Replace = "*Media1"
                     if self.media1 == "0":
@@ -740,7 +847,8 @@ class ActionBatch:
                         repopath,
                         "Media1.lst",
                         "Media1_{}.lst".format(
-                            os.path.basename(repodir.attrib["folder"]).strip("*") + repodir.get("archs", arch)
+                            os.path.basename(repodir.attrib["folder"]).strip("*")
+                            + repodir.get("archs", arch)
                         ),
                         "*Media1",
                         Media1Replace,
@@ -812,7 +920,9 @@ class ActionBatch:
             self.p("iso_folder[{}]='{}/'".format(k, v), f)
 
     def gen_print_array_hdd_folder(self, f):
-        if ((len(self.hdd_folder) > 1) or (self.hdd_folder and self.isos)) and len(self.flavors) == 1:
+        if ((len(self.hdd_folder) > 1) or (self.hdd_folder and self.isos)) and len(
+            self.flavors
+        ) == 1:
             self.p("declare -A hdd_folder", f)
             for k, v in self.hdd_folder.items():
                 self.p("hdd_folder[{}]='{}'".format(k, v), f)
@@ -842,13 +952,22 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
     def gen_print_rsync_iso(self, f):
         print(cfg.header, file=f)
         self.gen_print_array_no_rsync(f)
-        if ((len(self.hdds) > 1 and (not self.isos)) or (self.isos and self.hdds)) and len(self.flavors) < 2:
+        if (
+            (len(self.hdds) > 1 and (not self.isos)) or (self.isos and self.hdds)
+        ) and len(self.flavors) < 2:
             self.gen_print_array_hdd_folder(f)
             if self.archs == "armv7hl":
-                self.p(cfg.rsync_hdds, f, "grep ${arch}", "grep ${arch//armv7hl/armv7l}")
+                self.p(
+                    cfg.rsync_hdds, f, "grep ${arch}", "grep ${arch//armv7hl/armv7l}"
+                )
             else:
                 self.p(cfg.rsync_hdds, f)
-        elif self.isos or self.iso_5 or (self.hdds and not self.productpath().startswith("http")) or self.assets:
+        elif (
+            self.isos
+            or self.iso_5
+            or (self.hdds and not self.productpath().startswith("http"))
+            or self.assets
+        ):
             self.gen_print_array_flavor_filter(f)
             self.gen_print_array_iso_folder(f)
             if self.mask:
@@ -906,11 +1025,11 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
             self.p(cfg.rsync_repo_buildid, f)
             for repo in self.reposmultiarch:
                 rsync_timeout = repo.get("rsynctimeout", self.rsync_timeout)
-                destpath = repo.get("folder", repo.tag)
-                dest = os.path.basename(destpath)
                 self.p(
                     cfg.rsync_repomultiarch(
-                        repo.get("folder", repo.tag), repo.get("debug", ""), repo.get("source", "")
+                        repo.get("folder", repo.tag),
+                        repo.get("debug", ""),
+                        repo.get("source", ""),
                     ),
                     f,
                     "RSYNCTIMEOUT",
@@ -943,7 +1062,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                     cfg.rsync_remodir_multiarch,
                     f,
                     "files_repo.lst",
-                    "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                    "files_repo_{}.lst".format(
+                        os.path.basename(r.attrib["folder"]).strip("*")
+                    ),
                     "PRODUCTREPOPATH",
                     self.productrepopath() + xtrapath + r.attrib["folder"],
                     "RSYNCTIMEOUT",
@@ -954,7 +1075,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                         cfg.rsync_remodir_multiarch_debug,
                         f,
                         "files_repo.lst",
-                        "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                        "files_repo_{}.lst".format(
+                            os.path.basename(r.attrib["folder"]).strip("*")
+                        ),
                         "PRODUCTREPOPATH",
                         self.productrepopath() + xtrapath + r.attrib["folder"],
                         "RSYNCFILTER",
@@ -967,11 +1090,19 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 continue
 
             if not r.attrib.get("dest", ""):
-                self.p(cfg.rsync_repodir1, f, "mid=''", "mid='{}'".format(r.attrib.get("mid", "")))
+                self.p(
+                    cfg.rsync_repodir1,
+                    f,
+                    "mid=''",
+                    "mid='{}'".format(r.attrib.get("mid", "")),
+                )
             elif self.media1 == "0":
                 self.p(
                     cfg.rsync_repodir1_dest_media0(
-                        r.attrib["dest"], r.get("debug", ""), r.get("source", ""), r.attrib["folder"]
+                        r.attrib["dest"],
+                        r.get("debug", ""),
+                        r.get("source", ""),
+                        r.attrib["folder"],
                     ),
                     f,
                 )
@@ -990,7 +1121,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 "PRODUCTREPOPATH",
                 self.productpath() + xtrapath + r.attrib["folder"] + suffix,
                 "files_repo.lst",
-                "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                "files_repo_{}.lst".format(
+                    os.path.basename(r.attrib["folder"]).strip("*")
+                ),
                 "Media2",
                 "Media1",
                 "-debuginfo",
@@ -1000,7 +1133,12 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
             )
             if r.attrib.get("debug", ""):
                 if not r.attrib.get("dest", ""):
-                    self.p(cfg.rsync_repodir1, f, "mid=''", "mid='{}'".format(r.attrib.get("mid", "")))
+                    self.p(
+                        cfg.rsync_repodir1,
+                        f,
+                        "mid=''",
+                        "mid='{}'".format(r.attrib.get("mid", "")),
+                    )
                 else:
                     self.p(cfg.rsync_repodir1_dest(r.attrib["dest"]), f)
                 for ren in self.renames:
@@ -1011,7 +1149,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                     "PRODUCTREPOPATH",
                     self.productpath() + xtrapath + r.attrib["folder"] + suffix,
                     "files_repo.lst",
-                    "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                    "files_repo_{}.lst".format(
+                        os.path.basename(r.attrib["folder"]).strip("*")
+                    ),
                     "RSYNCFILTER",
                     " --include=PACKAGES --exclude={aarch64,armv7hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*".replace(
                         "PACKAGES", r.attrib["debug"]
@@ -1019,7 +1159,12 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 )
             if r.attrib.get("source", ""):
                 if not r.attrib.get("dest", ""):
-                    self.p(cfg.rsync_repodir1, f, "mid=''", "mid='{}'".format(r.attrib.get("mid", "")))
+                    self.p(
+                        cfg.rsync_repodir1,
+                        f,
+                        "mid=''",
+                        "mid='{}'".format(r.attrib.get("mid", "")),
+                    )
                 else:
                     self.p(cfg.rsync_repodir1_dest(r.attrib["dest"]), f)
                 for ren in self.renames:
@@ -1031,7 +1176,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                         "PRODUCTREPOPATH",
                         self.productpath() + xtrapath + r.attrib["folder"] + suffix,
                         "files_repo.lst",
-                        "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                        "files_repo_{}.lst".format(
+                            os.path.basename(r.attrib["folder"]).strip("*")
+                        ),
                         "RSYNCFILTER",
                         " --include=PACKAGES --exclude={aarch64,armv7hl,i586,i686,noarch,nosrc,ppc64,ppc64le,riscv64,s390x,src,x86_64}/*".replace(
                             "PACKAGES", r.attrib["source"]
@@ -1100,22 +1247,53 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
             destpath = destpath.rstrip("/")
             dest = os.path.basename(destpath)
             self.p(' echo " REPO_{}={}-$buildex" \\\\'.format(imultiarch, dest), f)
-            self.p(' echo " REPO_{}={}-$buildex" \\\\'.format(repo.tag.upper(), dest), f)
+            self.p(
+                ' echo " REPO_{}={}-$buildex" \\\\'.format(repo.tag.upper(), dest), f
+            )
             imultiarch = imultiarch + 1
             if repo.get("debug", ""):
-                self.p(' echo " REPO_{}={}-Debug-$buildex" \\\\'.format(imultiarch, dest), f)
-                self.p(' echo " REPO_{}_DEBUG={}-Debug-$buildex" \\\\'.format(repo.tag.upper(), dest), f)
-                self.p(" echo \" REPO_{}_DEBUG_PACKAGES='{}'\" \\\\".format(repo.tag.upper(), repo.get("debug", "")), f)
+                self.p(
+                    ' echo " REPO_{}={}-Debug-$buildex" \\\\'.format(imultiarch, dest),
+                    f,
+                )
+                self.p(
+                    ' echo " REPO_{}_DEBUG={}-Debug-$buildex" \\\\'.format(
+                        repo.tag.upper(), dest
+                    ),
+                    f,
+                )
+                self.p(
+                    " echo \" REPO_{}_DEBUG_PACKAGES='{}'\" \\\\".format(
+                        repo.tag.upper(), repo.get("debug", "")
+                    ),
+                    f,
+                )
                 imultiarch = imultiarch + 1
             if repo.get("source", ""):
-                self.p(' echo " REPO_{}={}-Source-$buildex" \\\\'.format(imultiarch, dest), f)
-                self.p(' echo " REPO_{}_SOURCE={}-Source-$buildex" \\\\'.format(repo.tag.upper(), dest), f)
                 self.p(
-                    " echo \" REPO_{}_SOURCE_PACKAGES='{}'\" \\\\".format(repo.tag.upper(), repo.get("source", "")), f
+                    ' echo " REPO_{}={}-Source-$buildex" \\\\'.format(imultiarch, dest),
+                    f,
+                )
+                self.p(
+                    ' echo " REPO_{}_SOURCE={}-Source-$buildex" \\\\'.format(
+                        repo.tag.upper(), dest
+                    ),
+                    f,
+                )
+                self.p(
+                    " echo \" REPO_{}_SOURCE_PACKAGES='{}'\" \\\\".format(
+                        repo.tag.upper(), repo.get("source", "")
+                    ),
+                    f,
                 )
                 imultiarch = imultiarch + 1
             if imultiarch > 0 and repo.get("mirror", 0) and not mirrorsalreadyadded:
-                self.p(cfg.openqa_call_repo_unconditional(), f, "REPO0_ISO", "{}-$buildex".format(dest))
+                self.p(
+                    cfg.openqa_call_repo_unconditional(),
+                    f,
+                    "REPO0_ISO",
+                    "{}-$buildex".format(dest),
+                )
                 mirrorsalreadyadded = True
 
         if len(self.iso1) > 0:
@@ -1145,9 +1323,16 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
 
         i = 0
         isos = self.isos.copy()
-        if ((len(self.hdds) > 1 and not self.isos) or (self.hdds and self.isos)) and len(self.flavors) == 1:
+        if (
+            (len(self.hdds) > 1 and not self.isos) or (self.hdds and self.isos)
+        ) and len(self.flavors) == 1:
             if self.archs == "armv7hl":
-                self.p(cfg.openqa_call_start_hdds, f, "grep ${arch}", "grep ${arch//armv7hl/armv7l}")
+                self.p(
+                    cfg.openqa_call_start_hdds,
+                    f,
+                    "grep ${arch}",
+                    "grep ${arch//armv7hl/armv7l}",
+                )
             else:
                 self.p(cfg.openqa_call_start_hdds, f, "i=1", "i=" + self.offset)
         elif self.hdds or (self.assets and not self.isos):
@@ -1212,14 +1397,23 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
 
         if self.repos or self.repolink:
             if self.ag.brand == "ibs":
-                self.p(" i=9", f)  # temporary to simplify diff with old rsync scripts, may be removed later
+                self.p(
+                    " i=9", f
+                )  # temporary to simplify diff with old rsync scripts, may be removed later
             # some trickery for REPO_SLE_ vs REPO_SL_ variables in ibs
             sl = "SLE_"
             for r in self.repos:
                 if r.tag.startswith("SL"):
                     sl = ""
                     break
-            self.p(cfg.openqa_call_repot(self.build_id_from_iso, self.repos), f, "REPOTYPE", "''", "REPOPREFIX", sl)
+            self.p(
+                cfg.openqa_call_repot(self.build_id_from_iso, self.repos),
+                f,
+                "REPOTYPE",
+                "''",
+                "REPOPREFIX",
+                sl,
+            )
 
         repodirs = self.repodirs
         if not repodirs and self.repolink:
@@ -1237,7 +1431,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 )
             else:
                 self.p(
-                    cfg.openqa_call_repot1_dest(r.attrib["dest"], r.get("debug", ""), r.get("source", "")),
+                    cfg.openqa_call_repot1_dest(
+                        r.attrib["dest"], r.get("debug", ""), r.get("source", "")
+                    ),
                     f,
                     "REPOKEY",
                     r.attrib.get("rename", r.tag),
@@ -1247,10 +1443,18 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 self.p("            dest=${{dest//{}/{}}}".format(ren[0], ren[1]), f)
             if i == 0:
                 self.p(
-                    "            [ $i != 0 ] || {{ {};  }}".format(cfg.openqa_call_repo0()), f, "REPO0_ISO", "$dest", f
+                    "            [ $i != 0 ] || {{ {};  }}".format(
+                        cfg.openqa_call_repo0()
+                    ),
+                    f,
+                    "REPO0_ISO",
+                    "$dest",
+                    f,
                 )
             media_filter = ""
-            if self.media1 != "0" and (r.attrib.get("debug", "") == "" or r.attrib.get("source", "") == ""):
+            if self.media1 != "0" and (
+                r.attrib.get("debug", "") == "" or r.attrib.get("source", "") == ""
+            ):
                 if r.attrib.get("debug", "") == "" and r.attrib.get("source", "") == "":
                     media_filter = "| grep Media1 "
                 elif r.attrib.get("debug", "") == "":
@@ -1261,7 +1465,9 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
                 cfg.openqa_call_repot2.format(media_filter),
                 f,
                 "files_repo.lst",
-                "files_repo_{}.lst".format(os.path.basename(r.attrib["folder"]).strip("*")),
+                "files_repo_{}.lst".format(
+                    os.path.basename(r.attrib["folder"]).strip("*")
+                ),
                 "DEBUG_PACKAGES",
                 r.attrib.get("debug", "").strip("{}"),
                 "SOURCE_PACKAGES",
@@ -1289,7 +1495,10 @@ def parse_dir(root, d, files):
 
         pattern = rootXml.attrib.get("project_pattern", "")
         if not pattern:
-            print("Ignoring [" + f + "]: Cannot find attribute project_pattern", file=sys.stderr)
+            print(
+                "Ignoring [" + f + "]: Cannot find attribute project_pattern",
+                file=sys.stderr,
+            )
             continue
 
         try:
@@ -1307,26 +1516,39 @@ def parse_dir(root, d, files):
         version = found_match.groupdict().get("version", "")
         if version.find("'") != -1:
             print(
-                "OBS: Ignoring [" + d + "]: Version cannot contain quote characters; got: " + version, file=sys.stderr
+                "OBS: Ignoring ["
+                + d
+                + "]: Version cannot contain quote characters; got: "
+                + version,
+                file=sys.stderr,
             )
             continue
 
         dist_path = rootXml.attrib.get("dist_path", "")
         if dist_path.find('"') != -1:
             print(
-                "OBS: Ignoring [" + d + "]: dist_path cannot contain quote characters; got: " + dist_path,
+                "OBS: Ignoring ["
+                + d
+                + "]: dist_path cannot contain quote characters; got: "
+                + dist_path,
                 file=sys.stderr,
             )
             continue
         if dist_path.find("`") != -1:
             print(
-                "OBS: Ignoring [" + d + "]: dist_path cannot contain backtick characters; got: " + dist_path,
+                "OBS: Ignoring ["
+                + d
+                + "]: dist_path cannot contain backtick characters; got: "
+                + dist_path,
                 file=sys.stderr,
             )
             continue
         if dist_path.find("$(") != -1:
             print(
-                "OBS: Ignoring [" + d + "]: dist_path cannot contain '$(' characters; got: " + dist_path,
+                "OBS: Ignoring ["
+                + d
+                + "]: dist_path cannot contain '$(' characters; got: "
+                + dist_path,
                 file=sys.stderr,
             )
             continue
@@ -1338,7 +1560,9 @@ def parse_dir(root, d, files):
                 if v and v.find("'") == -1:
                     myenv[k] = v
             try:
-                output = check_output(["echo " + dist_path], shell=True, executable="/bin/bash", env=myenv).decode()
+                output = check_output(
+                    ["echo " + dist_path], shell=True, executable="/bin/bash", env=myenv
+                ).decode()
                 success = True
             except CalledProcessError as e:
                 output = e.output.decode()
@@ -1357,7 +1581,7 @@ def parse_dir(root, d, files):
 
 def detect_xml_dir(project):
     # if project has no path
-    if not "/" in project:
+    if "/" not in project:
         return os.getcwd()[-3:]
 
     return os.path.dirname(project)[-3:]
@@ -1377,9 +1601,9 @@ def gen_files(project):
         return 1
 
     if xmldir == "abs":
-        import abs
+        pass
     if xmldir == "ibs":
-        import ibs
+        pass
 
     a = ActionGenerator(os.getcwd(), project, dist_path, version, xmldir)
     if a is None:
@@ -1410,7 +1634,7 @@ if __name__ == "__main__":
     parser.add_argument("project", nargs="?", help="Folder matching OBS project")
 
     class Args:
-        pass
+        project: str | None = None
 
     args = Args()
     parser.parse_args(namespace=args)


### PR DESCRIPTION
Replace black with ruff and ty for Python style enforcement. The `requires-python = ">=3.10"` constraint in pyproject.toml applies only to `uv run` dev tooling, which runs on Tumbleweed in the CircleCI style job. Runtime scripts in script/ remain compatible with Python 3.6 on Leap 15.5 mostly, however the image was updated from Leap 15.5 to Leap 16.0 (which runs also python 3.13).

Changes:
- E701 (multiple statements on one line): split compound conditions and function definitions across multiple lines in script/cfg.py and script/scriptgen.py
- E731 (lambda assignment): convert rsync_iso lambda to a proper function definition in script/cfg.py
- Replace triple-quoted strings with double-quote delimiters throughout script/cfg.py for consistency
- Small refactoring in script/scriptgen.py: replace `is not` None chains with `any()` for readability when checking multiple optional parameters

Issue: https://progress.opensuse.org/issues/191575