### PR TITLE
Update CI image to Leap 16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   unit:
     docker:
-      - image: registry.opensuse.org/opensuse/leap:15.5
+      - image: registry.opensuse.org/opensuse/leap:16.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Leap 15.5 has been EOL for a while, so let's update the circleci stuff to use 16.0
