### PR TITLE
scriptgen.py: Declare iso_folder to avoid arithmetic evaluation of flavor names

### DIFF
--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -806,8 +806,7 @@ class ActionBatch:
             self.p("flavor_distri[{}]='{}'".format(fl, distri), f)
 
     def gen_print_array_iso_folder(self, f):
-        if self.iso_folder:
-            self.p("declare -A iso_folder", f)
+        self.p("declare -A iso_folder", f)
         for k, v in self.iso_folder.items():
             self.p("iso_folder[{}]='{}/'".format(k, v), f)
 


### PR DESCRIPTION
Without declare -A, bash evaluates array keys as arithmetic expressions. Flavor names like `Online-Kernel-64kb-Baremetal` cause `value too great for base` errors.


If is added  flavor  `<flavor name="Online-Kernel-64kb-Baremetal" iso="Online" sha="512"/>` to project definition, it will fail with following error (variable content is treated as numerical):

```
make test_update_before_files
.
.
ibs/SUSE:SLFO:Products:SLES:16.1:TEST/base//print_rsync_iso.sh: line 35: Online-Kernel-64kb: value too great for base (error token is "64kb")
make: *** [Makefile:38: test_update_before_files] Error 1
```


Reference: https://progress.opensuse.org/issues/198665
MR with new flavors: https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/287