### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,9 +39,3 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-  - name: ask to resolve conflict
-    conditions:
-      - conflict
-    actions:
-      comment:
-        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,6 +30,15 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+  - name: automatic merge for dependabot updates
+    conditions:
+      - and: *base_checks
+      - and:
+          - base=master
+          - author=dependabot[bot]
+    actions:
+      merge:
+        method: squash
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.