### PR TITLE
rsync.sh: Fix recursive signal loop on SIGTERM

### DIFF
--- a/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
+++ b/profiles/apparmor.d/opt.openqa-trigger-from-obs.script.rsync.sh
@@ -44,6 +44,7 @@
   /usr/bin/ln ix,
   /usr/bin/ls ix,
   /usr/bin/mkdir ix,
+  /usr/bin/pkill ix,
   /usr/bin/rm ix,
   /usr/bin/rsync Px -> /opt/openqa-trigger-from-obs/script/rsync.sh//rsync,
   /usr/bin/sleep ix,

--- a/script/rsync.sh
+++ b/script/rsync.sh
@@ -78,7 +78,7 @@ set +e
 
     [ ! -e "$subfolder/print_openqa.sh" ] || bash -e "$subfolder/print_openqa.sh" 2>$logdir/generate_openqa.err > $logdir/openqa.cmd
 
-    trap 'kill -- -$pid 2>/dev/null || pkill -P $$; exit 1' TERM INT
+    trap 'pkill -P $pid 2>/dev/null; kill $pid 2>/dev/null; exit 1' TERM INT
 
     current_dir=$PWD/$logdir
     for f in {rsync_iso.cmd,rsync_repo.cmd,openqa.cmd}; do


### PR DESCRIPTION
- Prevents the subshell from recursively signaling itself.
- Ensures all background and grandchild rsync processes are cleanly terminated, leaving no orphans.
- Whitelists '/usr/bin/pkill' in the AppArmor profile to ensure signal termination remains fully functional when confined.

Related Progress Ticket: https://progress.opensuse.org/issues/196478