### PR TITLE
Allow overriding repositories from ISO when extracting iso as repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ PYTHON_RUN ?=
 test_python_style:
 	$(PYTHON_RUN) ruff check
 	$(PYTHON_RUN) ruff format --check
-	$(PYTHON_RUN) ty check
+	$(PYTHON_RUN) ty check --exclude script/ibs.py

--- a/script/cfg.py
+++ b/script/cfg.py
@@ -643,15 +643,20 @@ openqa_call_start_hdds = r"""
 
 
 # if MIRROREPO is set - expressions for FLAVORASREPOORS will evaluate to false
-def openqa_call_repo0():
-    return """ [ -z "FLAVORASREPOORSMIRRORREPO" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) == 0"MIRRORREPO" ] || {
-    echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\
+def openqa_call_repo0(add_ignored_iso_repo=False):
+    iso_as_repo = """\n REPO_ISO=${repo0folder} \\\\""" if add_ignored_iso_repo else r""
+    return (
+        """ [ -z "FLAVORASREPOORSMIRRORREPO" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) == 0"MIRRORREPO" ] || {
+    echo " MIRROR_PREFIX=http://openqa.opensuse.org/assets/repo \\\\"""
+        + iso_as_repo
+        + """
  SUSEMIRROR=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTP=http://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  MIRROR_HTTPS=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  INST_INSTALL_URL=https://openqa.opensuse.org/assets/repo/REPO0_ISO \\\\
  FULLURL=1 \\\\"
     }"""
+    )
 
 
 def openqa_call_repo_unconditional():

--- a/script/cfg.py
+++ b/script/cfg.py
@@ -104,9 +104,11 @@ for flavor in {FLAVORLIST,}; do
         """
         + (repo0folder if repo0folder else "")
         + """
-        [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || echo "[ -d /var/lib/openqa/factory/repo/$repo0folder ] || {
-    mkdir /var/lib/openqa/factory/repo/$repo0folder
-    bsdtar xf /var/lib/openqa/factory/iso/$dest -C /var/lib/openqa/factory/repo/$repo0folder
+        iso_repo="/var/lib/openqa/factory/repo/${repo0folder}"
+        [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || echo "[ -d "${iso_repo}" ] || {
+    mkdir $iso_repo
+    bsdtar xf /var/lib/openqa/factory/iso/$dest -C $iso_repo
+    ln -sf "$iso_repo" "/var/lib/openqa/factory/repo/fixed/VERSIONVALUE-${flavor}-${arch}-CURRENT"
 }"
         [ -z "FLAVORTOREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORTOREPOORS)$" ) -eq 0 ] || echo "cp -l /var/lib/openqa/factory/iso/$dest /var/lib/openqa/factory/repo/"
     done

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -174,6 +174,7 @@ class ActionBatch:
         self.fixed_iso = ""
         self.mask = ""
         self.iso_extract_as_repo = {}
+        self.iso_extract_ignore_repo_from_iso = False
         self.ln_iso_to_repo = {}
         self.mirror_repo = ""
         self.repos = []
@@ -397,6 +398,11 @@ class ActionBatch:
                     self.iso_folder[iso] = node.attrib["folder"]
                 if iso_attrib == "extract_as_repo":
                     self.iso_extract_as_repo[iso] = 1
+                    iso_extract_ignore_repo_from_iso = node.attrib.get(
+                        "ignore_repo_from_iso", False
+                    )
+                    if iso_extract_ignore_repo_from_iso:
+                        self.iso_extract_ignore_repo_from_iso = True
                 elif iso_attrib != "1":
                     if node.attrib.get("extract_as_repo", ""):
                         self.iso_extract_as_repo[iso] = 1
@@ -1409,14 +1415,17 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
             if self.iso_extract_as_repo.get(iso, 0) or self.iso_5:
                 destiso = "${repo0folder}"
                 i += 1
-                s = ""
-                if not self.fixed_iso:
-                    self.p(cfg.openqa_call_repo0(), f, "REPO0_ISO", destiso, f)
-                    s = cfg.openqa_call_repo0a + cfg.openqa_call_repo0b
-                else:
+                s = cfg.openqa_call_repo0a + cfg.openqa_call_repo0b
+                if self.fixed_iso:
                     s = cfg.openqa_call_repo0b
                     destiso = self.fixed_iso[:-4]
-                self.p(s, f, "REPO0_ISO", destiso)
+
+                if self.iso_extract_ignore_repo_from_iso:
+                    i -= 1
+                else:
+                    self.p(cfg.openqa_call_repo0(), f, "REPO0_ISO", destiso, f)
+                    self.p(s, f, "REPO0_ISO", destiso)
+
                 if self.ln_iso_to_repo.get(iso, 0):
                     self.p(s, f, "REPO_0", "REPO_999", "REPO0_ISO", destiso + ".iso")
                 if self.iso_5:
@@ -1499,7 +1508,7 @@ done < <(LANG=C.UTF-8 sort __envsub/files_asset.lst)""",
             if i == 0:
                 self.p(
                     "            [ $i != 0 ] || {{ {};  }}".format(
-                        cfg.openqa_call_repo0()
+                        cfg.openqa_call_repo0(self.iso_extract_ignore_repo_from_iso)
                     ),
                     f,
                     "REPO0_ISO",

--- a/script/scriptgen.py
+++ b/script/scriptgen.py
@@ -1668,7 +1668,8 @@ def gen_files(project):
         import abs  # noqa: F401
     if xmldir == "ibs":
         with suppress(ImportError):
-            import ibs  # noqa: F401  # ty: ignore[unresolved-import]
+            # https://github.com/astral-sh/ty/issues/2681 ignore unused-ignore-comment rule twice
+            import ibs  # noqa: F401 # ty: ignore[unused-ignore-comment, unresolved-import, unused-ignore-comment]
 
     a = ActionGenerator(os.getcwd(), project, dist_path, version, xmldir)
     if a is None:

--- a/t/abs/TestExtractAsRepo1/print_rsync_iso.before
+++ b/t/abs/TestExtractAsRepo1/print_rsync_iso.before
@@ -5,4 +5,5 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test
 [ -d /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 ] || {
     mkdir /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
     bsdtar xf /var/lib/openqa/factory/iso/my-DVD.x86_64-1.1.1-Build1.111.iso -C /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
+    ln -sf /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 /var/lib/openqa/factory/repo/fixed/1-DVD-x86_64-CURRENT
 }

--- a/t/obs/openSUSE:Factory:ToTest/net-agama/print_openqa.before
+++ b/t/obs/openSUSE:Factory:ToTest/net-agama/print_openqa.before
@@ -16,6 +16,7 @@
  REPO_2=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929-Source \
  REPO_3=openSUSE-Tumbleweed-oss-x86_64.license-Snapshot20250929 \
  REPO_4=openSUSE-Tumbleweed-non-oss-x86_64-Snapshot20250929 \
+ REPO_ISO=agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 \
  REPO_NON_OSS=openSUSE-Tumbleweed-non-oss-x86_64-Snapshot20250929 \
  REPO_OSS=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929 \
  REPO_OSS_DEBUG=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929-Debug \
@@ -44,6 +45,7 @@
  REPO_2=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929-Source \
  REPO_3=openSUSE-Tumbleweed-oss-x86_64.license-Snapshot20250929 \
  REPO_4=openSUSE-Tumbleweed-non-oss-x86_64-Snapshot20250929 \
+ REPO_ISO=agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 \
  REPO_NON_OSS=openSUSE-Tumbleweed-non-oss-x86_64-Snapshot20250929 \
  REPO_OSS=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929 \
  REPO_OSS_DEBUG=openSUSE-Tumbleweed-oss-x86_64-Snapshot20250929-Debug \

--- a/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
@@ -3,6 +3,7 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest
 [ -d /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso -C /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
+    ln -sf /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 /var/lib/openqa/factory/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256 /var/lib/openqa/factory/other/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256

--- a/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
@@ -1,4 +1,8 @@
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256 /var/lib/openqa/factory/other/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256
+[ -d /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 ] || {
+    mkdir /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
+    bsdtar xf /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso -C /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
+}
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256 /var/lib/openqa/factory/other/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256

--- a/t/obs/systemsmanagement:Agama:Devel/base/print_rsync_iso.before
+++ b/t/obs/systemsmanagement:Agama:Devel/base/print_rsync_iso.before
@@ -3,16 +3,19 @@ rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement
 [ -d /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.x86_64-9.0.0-openSUSE-Build17.25.iso -C /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25
+    ln -sf /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-x86_64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso /var/lib/openqa/factory/iso/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso.sha256 /var/lib/openqa/factory/other/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso.sha256
 [ -d /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso -C /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1
+    ln -sf /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-aarch64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso /var/lib/openqa/factory/iso/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso.sha256 /var/lib/openqa/factory/other/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso.sha256
 [ -d /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso -C /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1
+    ln -sf /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-ppc64le-CURRENT
 }

--- a/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
+++ b/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
@@ -3,5 +3,6 @@ rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement
 [ -d /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso -C /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9
+    ln -sf /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-s390x-CURRENT
 }
 cp -l /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso /var/lib/openqa/factory/repo/

--- a/xml/obs/openSUSE:Factory.xml
+++ b/xml/obs/openSUSE:Factory.xml
@@ -23,7 +23,7 @@
         <flavor name="Rescue-CD|GNOME-Live|KDE-Live|XFCE-Live" iso="1"/>
     </batch>
     <batch name="net-agama" folder="appliances/*/agama-installer*" archs="x86_64" repos="base">
-        <flavor name="agama-installer" iso="1" distri="opensuse"/>
+        <flavor name="agama-installer" iso="extract_as_repo" ignore_repo_from_iso="1" distri="opensuse"/>
         <flavor name="agama-install" iso="1" distri="microos"/>
     </batch>
     <batch name="jeos" folder="appliances/x86_64" archs="x86_64" repos="base">


### PR DESCRIPTION
At some point we might want to extract the iso as a repo, while keeping the already synced repositories also as variables so they can be used to
set up different installation methods (i.e baremetal), this allows the to use `REPO_ISO` as a base to locate i.e the kernel and initrd from the agama-installer iso

Additionally creates a convenient `$version-$flavor-$arch-CURRENT` link, that can be used in cases of static things like ipxe, see https://github.com/os-autoinst/os-autoinst-scripts/pull/635

ibs plugin changes: https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/293
