### PR TITLE
fix(script/cfg.py): Avoid stale/broken symlinks when unpacking the iso

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -105,10 +105,12 @@ for flavor in {FLAVORLIST,}; do
         + (repo0folder if repo0folder else "")
         + """
         iso_repo="/var/lib/openqa/factory/repo/${repo0folder}"
+        iso_repo_current_alias="/var/lib/openqa/factory/repo/fixed/VERSIONVALUE-${flavor}-${arch}-CURRENT"
         [ -z "FLAVORASREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORASREPOORS)$" ) -eq 0 ] || echo "[ -d "${iso_repo}" ] || {
     mkdir $iso_repo
     bsdtar xf /var/lib/openqa/factory/iso/$dest -C $iso_repo
-    ln -sf "$iso_repo" "/var/lib/openqa/factory/repo/fixed/VERSIONVALUE-${flavor}-${arch}-CURRENT"
+    rm -rf "$iso_repo_current_alias"
+    ln -s "$iso_repo" "$iso_repo_current_alias"
 }"
         [ -z "FLAVORTOREPOORS" ] || [ $( echo "$flavor" | grep -E -c "^(FLAVORTOREPOORS)$" ) -eq 0 ] || echo "cp -l /var/lib/openqa/factory/iso/$dest /var/lib/openqa/factory/repo/"
     done

--- a/t/abs/TestExtractAsRepo1/print_rsync_iso.before
+++ b/t/abs/TestExtractAsRepo1/print_rsync_iso.before
@@ -5,5 +5,6 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestExtractAsRepo1/test
 [ -d /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 ] || {
     mkdir /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
     bsdtar xf /var/lib/openqa/factory/iso/my-DVD.x86_64-1.1.1-Build1.111.iso -C /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111
-    ln -sf /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 /var/lib/openqa/factory/repo/fixed/1-DVD-x86_64-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/1-DVD-x86_64-CURRENT
+    ln -s /var/lib/openqa/factory/repo/my-DVD.x86_64-1.1.1-Build1.111 /var/lib/openqa/factory/repo/fixed/1-DVD-x86_64-CURRENT
 }

--- a/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
+++ b/t/obs/openSUSE:Factory:ToTest/net-agama/print_rsync_iso.before
@@ -3,7 +3,8 @@ rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest
 [ -d /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso -C /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929
-    ln -sf /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 /var/lib/openqa/factory/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT
+    ln -s /var/lib/openqa/factory/repo/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929 /var/lib/openqa/factory/repo/fixed/Tumbleweed-agama-installer-x86_64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso /var/lib/openqa/factory/iso/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso
 rsync --timeout=3600 -tlp4 --specials obspublish::openqa/openSUSE:Factory:ToTest/appliances/*/agama-installer*/*agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256 /var/lib/openqa/factory/other/agama-installer.x86_64-17.0.0-openSUSE-Snapshot20250929.iso.sha256

--- a/t/obs/systemsmanagement:Agama:Devel/base/print_rsync_iso.before
+++ b/t/obs/systemsmanagement:Agama:Devel/base/print_rsync_iso.before
@@ -3,19 +3,22 @@ rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement
 [ -d /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.x86_64-9.0.0-openSUSE-Build17.25.iso -C /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25
-    ln -sf /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-x86_64-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-x86_64-CURRENT
+    ln -s /var/lib/openqa/factory/repo/agama-installer.x86_64-9.0.0-openSUSE-Build17.25 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-x86_64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso /var/lib/openqa/factory/iso/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso.sha256 /var/lib/openqa/factory/other/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso.sha256
 [ -d /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.aarch64-9.0.0-openSUSE-Build18.1.iso -C /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1
-    ln -sf /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-aarch64-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-aarch64-CURRENT
+    ln -s /var/lib/openqa/factory/repo/agama-installer.aarch64-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-aarch64-CURRENT
 }
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso /var/lib/openqa/factory/iso/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso
 rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement:Agama:Devel//images/*/agama-installer:openSUSE//*agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso.sha256 /var/lib/openqa/factory/other/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso.sha256
 [ -d /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1.iso -C /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1
-    ln -sf /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-ppc64le-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-ppc64le-CURRENT
+    ln -s /var/lib/openqa/factory/repo/agama-installer.ppc64le-9.0.0-openSUSE-Build18.1 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-ppc64le-CURRENT
 }

--- a/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
+++ b/t/obs/systemsmanagement:Agama:Devel/s390x/print_rsync_iso.before
@@ -3,6 +3,7 @@ rsync --timeout=3600 -tlp4 --specials obspublish-other::openqa/systemsmanagement
 [ -d /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 ] || {
     mkdir /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9
     bsdtar xf /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso -C /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9
-    ln -sf /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-s390x-CURRENT
+    rm -rf /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-s390x-CURRENT
+    ln -s /var/lib/openqa/factory/repo/agama-installer.s390x-9.0.0-openSUSE-Build17.9 /var/lib/openqa/factory/repo/fixed/agama-9.0-agama-installer-s390x-CURRENT
 }
 cp -l /var/lib/openqa/factory/iso/agama-installer.s390x-9.0.0-openSUSE-Build17.9.iso /var/lib/openqa/factory/repo/


### PR DESCRIPTION
Prevent a silent failure and nested directory link creation when the
destination target is a physical directory or a resolved symbolic link
to a directory.

Force `ln` to fail if the target is somehow converted into a directory
(e.g manual intevention)

IBS will need: https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/295
