### PR TITLE
fix(script/cfg.py): Only treat known disk image suffixes as HDD assets

### DIFF
--- a/script/cfg.py
+++ b/script/cfg.py
@@ -95,8 +95,7 @@ for flavor in {FLAVORLIST,}; do
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
         [[ ! $dest =~ \.spdx\.json$  ]] || asset_folder=iso
         [[ ! $dest =~ \.tar$  ]] || asset_folder=iso
-        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)$ ]] || asset_folder=hdd
-        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)\.(xz|gz)$ ]] || asset_folder=hdd
+        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)(\.(xz|gz))?$ ]] || asset_folder=hdd
         """
         + rsync_commands(checksum)
         + """

--- a/script/cfg.py
+++ b/script/cfg.py
@@ -95,7 +95,8 @@ for flavor in {FLAVORLIST,}; do
         [[ ! $dest =~ \.iso$  ]] || asset_folder=iso
         [[ ! $dest =~ \.spdx\.json$  ]] || asset_folder=iso
         [[ ! $dest =~ \.tar$  ]] || asset_folder=iso
-        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx|xz)$ ]] || asset_folder=hdd
+        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)$ ]] || asset_folder=hdd
+        [[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)\.(xz|gz)$ ]] || asset_folder=hdd
         """
         + rsync_commands(checksum)
         + """

--- a/t/abs/TestAssetFolder1/files_iso.lst
+++ b/t/abs/TestAssetFolder1/files_iso.lst
@@ -1,0 +1,5 @@
+my-Test.x86_64-1.1.1-Build1.111.qcow2
+my-Test.x86_64-1.1.1-Build1.111.raw.xz
+my-Test.x86_64-1.1.1-Build1.111.raw.gz
+my-Test.x86_64-1.1.1-Build1.111.tar.xz
+my-Test.x86_64-1.1.1-Build1.111.appx

--- a/t/abs/TestAssetFolder1/print_openqa.before
+++ b/t/abs/TestAssetFolder1/print_openqa.before
@@ -1,0 +1,55 @@
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.qcow2.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_HDD_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.qcow2.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=QCOW2 \
+ HDD_1=my-Test.x86_64-1.1.1-Build1.111.qcow2 \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_HDD_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=RAWXZ \
+ HDD_1=my-Test.x86_64-1.1.1-Build1.111.raw.xz \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.raw.gz.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_HDD_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.gz.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=RAWGZ \
+ HDD_1=my-Test.x86_64-1.1.1-Build1.111.raw.gz \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_1=my-Test.x86_64-1.1.1-Build1.111.tar.xz \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.tar.xz.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_ASSET_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.tar.xz.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=TARXZ \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+
+/usr/bin/openqa-cli api -X post isos?async=1 \
+ ARCH=x86_64 \
+ ASSET_1=my-Test.x86_64-1.1.1-Build1.111.appx \
+ ASSET_256=my-Test.x86_64-1.1.1-Build1.111.appx.sha256 \
+ BUILD=1.111 \
+ CHECKSUM_ASSET_1=$(cut -b-64 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.appx.sha256 | grep -E '[0-9a-f]{5,40}' | head -n1) \
+ DISTRI=distri \
+ FLAVOR=APPX \
+ VERSION=1 \
+ _DEPRIORITIZEBUILD=1
+

--- a/t/abs/TestAssetFolder1/print_rsync_iso.before
+++ b/t/abs/TestAssetFolder1/print_rsync_iso.before
@@ -1,0 +1,10 @@
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.qcow2 /var/lib/openqa/factory/hdd/my-Test.x86_64-1.1.1-Build1.111.qcow2
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.qcow2.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.qcow2.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.xz /var/lib/openqa/factory/hdd/my-Test.x86_64-1.1.1-Build1.111.raw.xz
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.xz.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.gz /var/lib/openqa/factory/hdd/my-Test.x86_64-1.1.1-Build1.111.raw.gz
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.raw.gz.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.raw.gz.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.tar.xz /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.tar.xz
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.tar.xz.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.tar.xz.sha256
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.appx /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.appx
+rsync --timeout=3600 -tlp4 --specials obspublish::openqa/TestAssetFolder1/test/*my-Test.x86_64-1.1.1-Build1.111.appx.sha256 /var/lib/openqa/factory/other/my-Test.x86_64-1.1.1-Build1.111.appx.sha256

--- a/xml/abs/TestAssetFolder.xml
+++ b/xml/abs/TestAssetFolder.xml
@@ -1,0 +1,22 @@
+<!-- The purpose of this test is to pin down the destination folder that assets are
+     rsynced to: disk images, including compressed ones, belong to factory/hdd,
+     everything else belongs to factory/other. The folder has to agree with the
+     openQA variable the asset is announced as (HDD_x vs ASSET_x), otherwise the
+     asset is looked up in a directory it was never copied to. -->
+<openQA project_pattern="TestAssetFolder(?P&lt;version&gt;[1-9])" dist_path="test" archs="x86_64" media1="0">
+    <flavor name="QCOW2" distri="distri">
+        <asset filemask="qcow2$"/>
+    </flavor>
+    <flavor name="RAWXZ" distri="distri">
+        <asset filemask="raw\.xz$"/>
+    </flavor>
+    <flavor name="RAWGZ" distri="distri">
+        <asset filemask="raw\.gz$"/>
+    </flavor>
+    <flavor name="TARXZ" distri="distri">
+        <asset filemask="tar\.xz$"/>
+    </flavor>
+    <flavor name="APPX" distri="distri">
+        <asset filemask="appx$"/>
+    </flavor>
+</openQA>


### PR DESCRIPTION
## Problem

The rsync destination folder is chosen in `rsync_isos()` by matching the file suffix:

```bash
[[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx|xz)$ ]] || asset_folder=hdd
```

The trailing `xz` is a catch-all, so **any** compressed file ending in `.xz` is rsynced into `$factory/hdd/`.

The openQA variable name is derived independently, by `openqa_call_start_ex()`, which maps only an explicit list of disk image suffixes to `HDD_1`:

```
\.(hdd|qcow2|raw|raw\.xz|raw\.gz|vhdx\.xz|vmdk|vmdk\.xz)$
```

and falls back to `ASSET_1` for everything else.

The two classifiers therefore disagree for any `.xz` file that is not a disk image. Such a file is copied to `$factory/hdd/`, while openQA is told `ASSET_1=<file>` and resolves it under `$factory/other/`. The asset is never found and the jobs fail. The `.sha256` sibling already lands in `$factory/other/` correctly, which makes the mismatch easy to overlook.

## Fix

Split the single rule in two and restrict the compressed variant to the same disk image suffixes `openqa_call_start_ex()` knows about, so both classifiers agree:

```bash
[[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)$ ]] || asset_folder=hdd
[[ ! $dest =~ \.(qcow2|raw|vhd|vmdk|vhdx)\.(xz|gz)$ ]] || asset_folder=hdd
```

## Impact

`.raw.xz` is the only compressed suffix currently produced by any flavor (8 occurrences across `t/obs/*/*/files_iso.lst`). It keeps its `$factory/hdd/` destination, so **no test fixture changes** and `make test` stays at 162 passed / 0 failures.

The bug surfaced while preparing the switch of the openSUSE Factory `WSL` flavor from the `.appx` image to the `.tar.xz` one produced by `kiwi-images-tbz` ([poo#203721](https://progress.opensuse.org/issues/203721)). That change is intentionally kept out of this PR and will be submitted separately; it exercises this code path and is the first consumer of a non-disk-image `.xz` asset.